### PR TITLE
feat: add issue sub-issue add/remove/list commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `gh cherry issue sub-issue add/remove/list` commands to manage sub-issue relationships
 - `gh cherry issue create` command with issue type support (`-T` flag)
 - `gh cherry issue types` command to list available issue types for a repository
 - `gh cherry pr diff` command with annotated L/R line numbers for AI agent review workflows

--- a/cmd/issue.go
+++ b/cmd/issue.go
@@ -1,7 +1,9 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/EurFelux/gh-cherry/internal/ghcli"
 	"github.com/EurFelux/gh-cherry/internal/issue"
@@ -37,12 +39,51 @@ func init() {
 	}
 	issueTypesCmd.Flags().StringP("repo", "R", "", "Repository in owner/repo format")
 
+	subIssueAddCmd := &cobra.Command{
+		Use:   "add <parent-number> <child-number>",
+		Short: "Add a sub-issue relationship",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runSubIssueAddRemove(cmd, args, "add")
+		},
+	}
+	subIssueAddCmd.Flags().StringP("repo", "R", "", "Repository in owner/repo format")
+
+	subIssueRemoveCmd := &cobra.Command{
+		Use:   "remove <parent-number> <child-number>",
+		Short: "Remove a sub-issue relationship",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runSubIssueAddRemove(cmd, args, "remove")
+		},
+	}
+	subIssueRemoveCmd.Flags().StringP("repo", "R", "", "Repository in owner/repo format")
+
+	subIssueListCmd := &cobra.Command{
+		Use:   "list <issue-number>",
+		Short: "List sub-issues of an issue",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runSubIssueList(cmd, args)
+		},
+	}
+	subIssueListCmd.Flags().StringP("repo", "R", "", "Repository in owner/repo format")
+
+	subIssueCmd := &cobra.Command{
+		Use:   "sub-issue",
+		Short: "Manage sub-issue relationships",
+	}
+	subIssueCmd.AddCommand(subIssueAddCmd)
+	subIssueCmd.AddCommand(subIssueRemoveCmd)
+	subIssueCmd.AddCommand(subIssueListCmd)
+
 	issueCmd := &cobra.Command{
 		Use:   "issue",
 		Short: "Enhanced issue management",
 	}
 	issueCmd.AddCommand(issueCreateCmd)
 	issueCmd.AddCommand(issueTypesCmd)
+	issueCmd.AddCommand(subIssueCmd)
 	rootCmd.AddCommand(issueCmd)
 }
 
@@ -78,6 +119,56 @@ func runIssueCreate(cmd *cobra.Command) error {
 		Repo:      getString("repo"),
 		Client:    client,
 	})
+}
+
+func runSubIssueAddRemove(cmd *cobra.Command, args []string, action string) error {
+	parentNumber, err := strconv.Atoi(args[0])
+	if err != nil {
+		return fmt.Errorf("invalid parent issue number %q: %w", args[0], err)
+	}
+
+	childNumber, err := strconv.Atoi(args[1])
+	if err != nil {
+		return fmt.Errorf("invalid child issue number %q: %w", args[1], err)
+	}
+
+	repoFlag, _ := cmd.Flags().GetString("repo")
+
+	owner, repo, err := issue.ResolveRepo(repoFlag)
+	if err != nil {
+		return err
+	}
+
+	client, err := ghcli.NewClient()
+	if err != nil {
+		return err
+	}
+
+	if action == "add" {
+		return issue.AddSubIssue(client, owner, repo, parentNumber, childNumber, os.Stdout)
+	}
+	return issue.RemoveSubIssue(client, owner, repo, parentNumber, childNumber, os.Stdout)
+}
+
+func runSubIssueList(cmd *cobra.Command, args []string) error {
+	issueNumber, err := strconv.Atoi(args[0])
+	if err != nil {
+		return fmt.Errorf("invalid issue number %q: %w", args[0], err)
+	}
+
+	repoFlag, _ := cmd.Flags().GetString("repo")
+
+	owner, repo, err := issue.ResolveRepo(repoFlag)
+	if err != nil {
+		return err
+	}
+
+	client, err := ghcli.NewClient()
+	if err != nil {
+		return err
+	}
+
+	return issue.ListSubIssues(client, owner, repo, issueNumber, os.Stdout)
 }
 
 func runIssueTypes(cmd *cobra.Command) error {

--- a/internal/issue/sub_issue.go
+++ b/internal/issue/sub_issue.go
@@ -1,0 +1,160 @@
+package issue
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/EurFelux/gh-cherry/internal/ghcli"
+)
+
+// SubIssueResult represents the result of an add or remove sub-issue operation.
+type SubIssueResult struct {
+	Parent int    `json:"parent"`
+	Child  int    `json:"child"`
+	Action string `json:"action"`
+}
+
+// SubIssueInfo represents a sub-issue in list output.
+type SubIssueInfo struct {
+	Number int    `json:"number"`
+	Title  string `json:"title"`
+	State  string `json:"state"`
+}
+
+// AddSubIssue creates a sub-issue relationship between parent and child issues.
+func AddSubIssue(client ghcli.Querier, owner, repo string, parentNumber, childNumber int, w io.Writer) error {
+	parentID, err := GetIssueNodeID(client, owner, repo, parentNumber)
+	if err != nil {
+		return fmt.Errorf("resolve parent issue: %w", err)
+	}
+
+	childID, err := GetIssueNodeID(client, owner, repo, childNumber)
+	if err != nil {
+		return fmt.Errorf("resolve child issue: %w", err)
+	}
+
+	query := `mutation($issueId: ID!, $subIssueId: ID!) {
+		addSubIssue(input: {issueId: $issueId, subIssueId: $subIssueId}) {
+			issue {
+				id
+			}
+		}
+	}`
+
+	var result struct {
+		AddSubIssue struct {
+			Issue struct {
+				ID string `json:"id"`
+			} `json:"issue"`
+		} `json:"addSubIssue"`
+	}
+
+	if err := client.Query(query, map[string]any{
+		"issueId":    parentID,
+		"subIssueId": childID,
+	}, &result); err != nil {
+		return fmt.Errorf("add sub-issue: %w", err)
+	}
+
+	return json.NewEncoder(w).Encode(SubIssueResult{
+		Parent: parentNumber,
+		Child:  childNumber,
+		Action: "added",
+	})
+}
+
+// RemoveSubIssue removes a sub-issue relationship between parent and child issues.
+func RemoveSubIssue(client ghcli.Querier, owner, repo string, parentNumber, childNumber int, w io.Writer) error {
+	parentID, err := GetIssueNodeID(client, owner, repo, parentNumber)
+	if err != nil {
+		return fmt.Errorf("resolve parent issue: %w", err)
+	}
+
+	childID, err := GetIssueNodeID(client, owner, repo, childNumber)
+	if err != nil {
+		return fmt.Errorf("resolve child issue: %w", err)
+	}
+
+	query := `mutation($issueId: ID!, $subIssueId: ID!) {
+		removeSubIssue(input: {issueId: $issueId, subIssueId: $subIssueId}) {
+			issue {
+				id
+			}
+		}
+	}`
+
+	var result struct {
+		RemoveSubIssue struct {
+			Issue struct {
+				ID string `json:"id"`
+			} `json:"issue"`
+		} `json:"removeSubIssue"`
+	}
+
+	if err := client.Query(query, map[string]any{
+		"issueId":    parentID,
+		"subIssueId": childID,
+	}, &result); err != nil {
+		return fmt.Errorf("remove sub-issue: %w", err)
+	}
+
+	return json.NewEncoder(w).Encode(SubIssueResult{
+		Parent: parentNumber,
+		Child:  childNumber,
+		Action: "removed",
+	})
+}
+
+// ListSubIssues lists all sub-issues of the given issue.
+func ListSubIssues(client ghcli.Querier, owner, repo string, issueNumber int, w io.Writer) error {
+	issueID, err := GetIssueNodeID(client, owner, repo, issueNumber)
+	if err != nil {
+		return fmt.Errorf("resolve issue: %w", err)
+	}
+
+	query := `query($id: ID!) {
+		node(id: $id) {
+			... on Issue {
+				subIssues(first: 100) {
+					totalCount
+					nodes {
+						number
+						title
+						state
+					}
+				}
+			}
+		}
+	}`
+
+	var result struct {
+		Node struct {
+			SubIssues struct {
+				TotalCount int            `json:"totalCount"`
+				Nodes      []SubIssueInfo `json:"nodes"`
+			} `json:"subIssues"`
+		} `json:"node"`
+	}
+
+	if err := client.Query(query, map[string]any{
+		"id": issueID,
+	}, &result); err != nil {
+		return fmt.Errorf("list sub-issues: %w", err)
+	}
+
+	nodes := result.Node.SubIssues.Nodes
+	if nodes == nil {
+		nodes = []SubIssueInfo{}
+	}
+
+	if err := json.NewEncoder(w).Encode(nodes); err != nil {
+		return err
+	}
+
+	if result.Node.SubIssues.TotalCount > len(nodes) {
+		_, _ = fmt.Fprintf(w, "showing %d of %d sub-issues\n", len(nodes), result.Node.SubIssues.TotalCount)
+	}
+
+	return nil
+}

--- a/internal/issue/sub_issue_test.go
+++ b/internal/issue/sub_issue_test.go
@@ -1,0 +1,218 @@
+package issue
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// callTrackingQuerier tracks GraphQL calls to serve different responses.
+type callTrackingQuerier struct {
+	calls     int
+	queryFunc func(callIndex int, query string, variables map[string]any, result any) error
+}
+
+func (m *callTrackingQuerier) Query(query string, variables map[string]any, result any) error {
+	idx := m.calls
+	m.calls++
+	return m.queryFunc(idx, query, variables, result)
+}
+
+// populateIssueNodeID populates a GetIssueNodeID response with the given ID.
+func populateIssueNodeID(result any, nodeID string) {
+	type respType = struct {
+		Repository struct {
+			Issue struct {
+				ID string `json:"id"`
+			} `json:"issue"`
+		} `json:"repository"`
+	}
+	r := result.(*respType)
+	r.Repository.Issue.ID = nodeID
+}
+
+func TestAddSubIssue(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		mock := &callTrackingQuerier{
+			queryFunc: func(callIndex int, query string, variables map[string]any, result any) error {
+				switch callIndex {
+				case 0: // GetIssueNodeID for parent
+					assert.Equal(t, 1, variables["number"])
+					populateIssueNodeID(result, "I_parent")
+				case 1: // GetIssueNodeID for child
+					assert.Equal(t, 4, variables["number"])
+					populateIssueNodeID(result, "I_child")
+				case 2: // addSubIssue mutation
+					assert.Contains(t, query, "addSubIssue")
+					assert.Equal(t, "I_parent", variables["issueId"])
+					assert.Equal(t, "I_child", variables["subIssueId"])
+				}
+				return nil
+			},
+		}
+
+		var buf bytes.Buffer
+		err := AddSubIssue(mock, "owner", "repo", 1, 4, &buf)
+		require.NoError(t, err)
+
+		var got SubIssueResult
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+		assert.Equal(t, 1, got.Parent)
+		assert.Equal(t, 4, got.Child)
+		assert.Equal(t, "added", got.Action)
+	})
+
+	t.Run("mutation error", func(t *testing.T) {
+		mock := &callTrackingQuerier{
+			queryFunc: func(callIndex int, _ string, _ map[string]any, result any) error {
+				if callIndex < 2 {
+					populateIssueNodeID(result, fmt.Sprintf("I_%d", callIndex))
+					return nil
+				}
+				return fmt.Errorf("permission denied")
+			},
+		}
+
+		var buf bytes.Buffer
+		err := AddSubIssue(mock, "owner", "repo", 1, 4, &buf)
+		assert.ErrorContains(t, err, "permission denied")
+	})
+
+	t.Run("parent not found", func(t *testing.T) {
+		mock := &callTrackingQuerier{
+			queryFunc: func(_ int, _ string, _ map[string]any, _ any) error {
+				return fmt.Errorf("issue #999 not found")
+			},
+		}
+
+		var buf bytes.Buffer
+		err := AddSubIssue(mock, "owner", "repo", 999, 4, &buf)
+		assert.ErrorContains(t, err, "resolve parent issue")
+	})
+}
+
+func TestRemoveSubIssue(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		mock := &callTrackingQuerier{
+			queryFunc: func(callIndex int, query string, variables map[string]any, result any) error {
+				switch callIndex {
+				case 0:
+					populateIssueNodeID(result, "I_parent")
+				case 1:
+					populateIssueNodeID(result, "I_child")
+				case 2:
+					assert.Contains(t, query, "removeSubIssue")
+					assert.Equal(t, "I_parent", variables["issueId"])
+					assert.Equal(t, "I_child", variables["subIssueId"])
+				}
+				return nil
+			},
+		}
+
+		var buf bytes.Buffer
+		err := RemoveSubIssue(mock, "owner", "repo", 1, 4, &buf)
+		require.NoError(t, err)
+
+		var got SubIssueResult
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+		assert.Equal(t, 1, got.Parent)
+		assert.Equal(t, 4, got.Child)
+		assert.Equal(t, "removed", got.Action)
+	})
+
+	t.Run("mutation error", func(t *testing.T) {
+		mock := &callTrackingQuerier{
+			queryFunc: func(callIndex int, _ string, _ map[string]any, result any) error {
+				if callIndex < 2 {
+					populateIssueNodeID(result, fmt.Sprintf("I_%d", callIndex))
+					return nil
+				}
+				return fmt.Errorf("not found")
+			},
+		}
+
+		var buf bytes.Buffer
+		err := RemoveSubIssue(mock, "owner", "repo", 1, 4, &buf)
+		assert.ErrorContains(t, err, "not found")
+	})
+}
+
+func TestListSubIssues(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		mock := &callTrackingQuerier{
+			queryFunc: func(callIndex int, query string, _ map[string]any, result any) error {
+				if callIndex == 0 {
+					populateIssueNodeID(result, "I_parent")
+					return nil
+				}
+				// list query
+				assert.Contains(t, query, "subIssues")
+				type respType = struct {
+					Node struct {
+						SubIssues struct {
+							TotalCount int            `json:"totalCount"`
+							Nodes      []SubIssueInfo `json:"nodes"`
+						} `json:"subIssues"`
+					} `json:"node"`
+				}
+				r := result.(*respType)
+				r.Node.SubIssues.TotalCount = 2
+				r.Node.SubIssues.Nodes = []SubIssueInfo{
+					{Number: 4, Title: "review start", State: "OPEN"},
+					{Number: 5, Title: "review submit", State: "OPEN"},
+				}
+				return nil
+			},
+		}
+
+		var buf bytes.Buffer
+		err := ListSubIssues(mock, "owner", "repo", 1, &buf)
+		require.NoError(t, err)
+
+		var got []SubIssueInfo
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+		assert.Len(t, got, 2)
+		assert.Equal(t, 4, got[0].Number)
+		assert.Equal(t, "review start", got[0].Title)
+		assert.Equal(t, "OPEN", got[0].State)
+	})
+
+	t.Run("empty list", func(t *testing.T) {
+		mock := &callTrackingQuerier{
+			queryFunc: func(callIndex int, _ string, _ map[string]any, result any) error {
+				if callIndex == 0 {
+					populateIssueNodeID(result, "I_parent")
+				}
+				return nil
+			},
+		}
+
+		var buf bytes.Buffer
+		err := ListSubIssues(mock, "owner", "repo", 1, &buf)
+		require.NoError(t, err)
+
+		output := strings.TrimSpace(buf.String())
+		assert.Equal(t, "[]", output)
+	})
+
+	t.Run("api error", func(t *testing.T) {
+		mock := &callTrackingQuerier{
+			queryFunc: func(callIndex int, _ string, _ map[string]any, result any) error {
+				if callIndex == 0 {
+					populateIssueNodeID(result, "I_parent")
+					return nil
+				}
+				return fmt.Errorf("server error")
+			},
+		}
+
+		var buf bytes.Buffer
+		err := ListSubIssues(mock, "owner", "repo", 1, &buf)
+		assert.ErrorContains(t, err, "server error")
+	})
+}


### PR DESCRIPTION
## Summary

- Add `issue sub-issue add/remove/list` commands to manage sub-issue relationships via GraphQL mutations/queries
- Resolves issue numbers to node IDs automatically, outputs JSON results
- Includes truncation warning when sub-issues exceed the 100-item page limit

Closes #14

## Test plan

- [x] `go test ./internal/issue/ -run "Test(Add|Remove|List)SubIssue"` — 8 test cases pass
- [x] `go build -o gh-cherry .` — builds successfully
- [x] `golangci-lint run` — 0 issues
- [x] `gofumpt -l .` — no formatting issues
- [ ] Manual: `gh cherry issue sub-issue add 1 4 -R owner/repo`
- [ ] Manual: `gh cherry issue sub-issue remove 1 4 -R owner/repo`
- [ ] Manual: `gh cherry issue sub-issue list 1 -R owner/repo`

🤖 Generated with [Claude Code](https://claude.com/claude-code)