### PR TITLE
feat: add review thread add command

### DIFF
--- a/cmd/review.go
+++ b/cmd/review.go
@@ -1,0 +1,84 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/EurFelux/gh-cherry/internal/ghcli"
+	"github.com/EurFelux/gh-cherry/internal/review"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	threadAddCmd := &cobra.Command{
+		Use:   "add <review-id>",
+		Short: "Add an inline comment thread to a pending review",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runReviewThreadAdd(cmd, args)
+		},
+	}
+
+	threadAddCmd.Flags().String("path", "", "File path to comment on")
+	threadAddCmd.Flags().Int("line", 0, "End line number")
+	threadAddCmd.Flags().StringP("body", "b", "", "Comment text")
+	threadAddCmd.Flags().String("body-file", "", "Read body from file")
+	threadAddCmd.Flags().String("side", "", "LEFT or RIGHT (default: RIGHT)")
+	threadAddCmd.Flags().Int("start-line", 0, "Multi-line start line")
+	threadAddCmd.Flags().String("start-side", "", "Multi-line start side (LEFT or RIGHT)")
+	_ = threadAddCmd.MarkFlagRequired("path")
+	_ = threadAddCmd.MarkFlagRequired("line")
+	threadAddCmd.MarkFlagsMutuallyExclusive("body", "body-file")
+	threadAddCmd.MarkFlagsOneRequired("body", "body-file")
+
+	threadCmd := &cobra.Command{
+		Use:   "thread",
+		Short: "Manage review comment threads",
+	}
+	threadCmd.AddCommand(threadAddCmd)
+
+	reviewCmd := &cobra.Command{
+		Use:   "review",
+		Short: "Enhanced pull request review operations",
+	}
+	reviewCmd.AddCommand(threadCmd)
+	rootCmd.AddCommand(reviewCmd)
+}
+
+func runReviewThreadAdd(cmd *cobra.Command, args []string) error {
+	body, _ := cmd.Flags().GetString("body")
+	bodyFile, _ := cmd.Flags().GetString("body-file")
+
+	if bodyFile != "" {
+		content, err := review.ReadBodyFile(bodyFile)
+		if err != nil {
+			return err
+		}
+		body = content
+	}
+
+	path, _ := cmd.Flags().GetString("path")
+	line, _ := cmd.Flags().GetInt("line")
+	side, _ := cmd.Flags().GetString("side")
+	startLine, _ := cmd.Flags().GetInt("start-line")
+	startSide, _ := cmd.Flags().GetString("start-side")
+
+	client, err := ghcli.NewClient()
+	if err != nil {
+		return err
+	}
+
+	result, err := review.AddThread(client, review.AddThreadOptions{
+		ReviewID:  args[0],
+		Path:      path,
+		Line:      line,
+		Body:      body,
+		Side:      side,
+		StartLine: startLine,
+		StartSide: startSide,
+	})
+	if err != nil {
+		return err
+	}
+
+	return review.PrintResult(result, os.Stdout)
+}

--- a/internal/review/thread.go
+++ b/internal/review/thread.go
@@ -1,0 +1,114 @@
+package review
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"slices"
+
+	"github.com/EurFelux/gh-cherry/internal/ghcli"
+)
+
+// ValidSides contains the allowed values for the side parameter.
+var ValidSides = []string{"LEFT", "RIGHT"}
+
+// AddThreadOptions holds the options for adding a review thread.
+type AddThreadOptions struct {
+	ReviewID  string
+	Path      string
+	Line      int
+	Body      string
+	Side      string
+	StartLine int
+	StartSide string
+}
+
+// AddThreadResult holds the result of adding a review thread.
+type AddThreadResult struct {
+	ThreadID string `json:"threadId"`
+}
+
+// AddThread adds an inline comment thread to a pending pull request review.
+func AddThread(client ghcli.Querier, opts AddThreadOptions) (*AddThreadResult, error) {
+	if opts.Side == "" {
+		opts.Side = "RIGHT"
+	}
+	if err := validateSide(opts.Side); err != nil {
+		return nil, err
+	}
+	if opts.StartSide != "" {
+		if err := validateSide(opts.StartSide); err != nil {
+			return nil, fmt.Errorf("invalid start-side: %w", err)
+		}
+	}
+
+	variables := map[string]any{
+		"reviewId": opts.ReviewID,
+		"path":     opts.Path,
+		"line":     opts.Line,
+		"side":     opts.Side,
+		"body":     opts.Body,
+	}
+	if opts.StartLine > 0 {
+		variables["startLine"] = opts.StartLine
+		if opts.StartSide == "" {
+			opts.StartSide = "RIGHT"
+		}
+		variables["startSide"] = opts.StartSide
+	}
+
+	query := `mutation($reviewId: ID!, $path: String!, $line: Int!, $side: DiffSide!, $body: String!, $startLine: Int, $startSide: DiffSide) {
+		addPullRequestReviewThread(input: {
+			pullRequestReviewId: $reviewId,
+			path: $path,
+			line: $line,
+			side: $side,
+			body: $body,
+			startLine: $startLine,
+			startSide: $startSide
+		}) {
+			thread {
+				id
+			}
+		}
+	}`
+
+	var result struct {
+		AddPullRequestReviewThread struct {
+			Thread struct {
+				ID string `json:"id"`
+			} `json:"thread"`
+		} `json:"addPullRequestReviewThread"`
+	}
+
+	if err := client.Query(query, variables, &result); err != nil {
+		return nil, fmt.Errorf("add review thread: %w", err)
+	}
+
+	return &AddThreadResult{
+		ThreadID: result.AddPullRequestReviewThread.Thread.ID,
+	}, nil
+}
+
+// PrintResult writes the result as JSON to the given writer.
+func PrintResult(result *AddThreadResult, w io.Writer) error {
+	enc := json.NewEncoder(w)
+	return enc.Encode(result)
+}
+
+func validateSide(side string) error {
+	if !slices.Contains(ValidSides, side) {
+		return fmt.Errorf("invalid side %q, must be LEFT or RIGHT", side)
+	}
+	return nil
+}
+
+// ReadBodyFile reads the body content from a file.
+func ReadBodyFile(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read body file: %w", err)
+	}
+	return string(data), nil
+}

--- a/internal/review/thread_test.go
+++ b/internal/review/thread_test.go
@@ -1,0 +1,225 @@
+package review
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockQuerier struct {
+	queryFunc func(query string, variables map[string]any, result any) error
+}
+
+func (m *mockQuerier) Query(query string, variables map[string]any, result any) error {
+	return m.queryFunc(query, variables, result)
+}
+
+func TestAddThread(t *testing.T) {
+	t.Run("single line comment", func(t *testing.T) {
+		mock := &mockQuerier{
+			queryFunc: func(query string, variables map[string]any, result any) error {
+				assert.Contains(t, query, "addPullRequestReviewThread")
+				assert.Equal(t, "PRR_123", variables["reviewId"])
+				assert.Equal(t, "src/main.go", variables["path"])
+				assert.Equal(t, 42, variables["line"])
+				assert.Equal(t, "RIGHT", variables["side"])
+				assert.Equal(t, "Fix this", variables["body"])
+				assert.NotContains(t, variables, "startLine")
+				assert.NotContains(t, variables, "startSide")
+
+				type respType = struct {
+					AddPullRequestReviewThread struct {
+						Thread struct {
+							ID string `json:"id"`
+						} `json:"thread"`
+					} `json:"addPullRequestReviewThread"`
+				}
+				r := result.(*respType)
+				r.AddPullRequestReviewThread.Thread.ID = "PRRT_abc"
+				return nil
+			},
+		}
+
+		res, err := AddThread(mock, AddThreadOptions{
+			ReviewID: "PRR_123",
+			Path:     "src/main.go",
+			Line:     42,
+			Body:     "Fix this",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "PRRT_abc", res.ThreadID)
+	})
+
+	t.Run("multi-line comment", func(t *testing.T) {
+		mock := &mockQuerier{
+			queryFunc: func(_ string, variables map[string]any, result any) error {
+				assert.Equal(t, 42, variables["line"])
+				assert.Equal(t, "LEFT", variables["side"])
+				assert.Equal(t, 40, variables["startLine"])
+				assert.Equal(t, "LEFT", variables["startSide"])
+
+				type respType = struct {
+					AddPullRequestReviewThread struct {
+						Thread struct {
+							ID string `json:"id"`
+						} `json:"thread"`
+					} `json:"addPullRequestReviewThread"`
+				}
+				r := result.(*respType)
+				r.AddPullRequestReviewThread.Thread.ID = "PRRT_multi"
+				return nil
+			},
+		}
+
+		res, err := AddThread(mock, AddThreadOptions{
+			ReviewID:  "PRR_123",
+			Path:      "src/main.go",
+			Line:      42,
+			Body:      "Refactor this block",
+			Side:      "LEFT",
+			StartLine: 40,
+			StartSide: "LEFT",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "PRRT_multi", res.ThreadID)
+	})
+
+	t.Run("defaults side to RIGHT", func(t *testing.T) {
+		mock := &mockQuerier{
+			queryFunc: func(_ string, variables map[string]any, result any) error {
+				assert.Equal(t, "RIGHT", variables["side"])
+
+				type respType = struct {
+					AddPullRequestReviewThread struct {
+						Thread struct {
+							ID string `json:"id"`
+						} `json:"thread"`
+					} `json:"addPullRequestReviewThread"`
+				}
+				r := result.(*respType)
+				r.AddPullRequestReviewThread.Thread.ID = "PRRT_default"
+				return nil
+			},
+		}
+
+		res, err := AddThread(mock, AddThreadOptions{
+			ReviewID: "PRR_123",
+			Path:     "file.go",
+			Line:     1,
+			Body:     "comment",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "PRRT_default", res.ThreadID)
+	})
+
+	t.Run("defaults start-side to RIGHT for multi-line", func(t *testing.T) {
+		mock := &mockQuerier{
+			queryFunc: func(_ string, variables map[string]any, result any) error {
+				assert.Equal(t, "RIGHT", variables["startSide"])
+
+				type respType = struct {
+					AddPullRequestReviewThread struct {
+						Thread struct {
+							ID string `json:"id"`
+						} `json:"thread"`
+					} `json:"addPullRequestReviewThread"`
+				}
+				r := result.(*respType)
+				r.AddPullRequestReviewThread.Thread.ID = "PRRT_x"
+				return nil
+			},
+		}
+
+		_, err := AddThread(mock, AddThreadOptions{
+			ReviewID:  "PRR_123",
+			Path:      "file.go",
+			Line:      10,
+			Body:      "comment",
+			StartLine: 5,
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("invalid side", func(t *testing.T) {
+		mock := &mockQuerier{
+			queryFunc: func(_ string, _ map[string]any, _ any) error {
+				t.Fatal("should not be called")
+				return nil
+			},
+		}
+
+		_, err := AddThread(mock, AddThreadOptions{
+			ReviewID: "PRR_123",
+			Path:     "file.go",
+			Line:     1,
+			Body:     "comment",
+			Side:     "MIDDLE",
+		})
+		assert.ErrorContains(t, err, `invalid side "MIDDLE"`)
+	})
+
+	t.Run("invalid start-side", func(t *testing.T) {
+		mock := &mockQuerier{
+			queryFunc: func(_ string, _ map[string]any, _ any) error {
+				t.Fatal("should not be called")
+				return nil
+			},
+		}
+
+		_, err := AddThread(mock, AddThreadOptions{
+			ReviewID:  "PRR_123",
+			Path:      "file.go",
+			Line:      10,
+			Body:      "comment",
+			StartLine: 5,
+			StartSide: "INVALID",
+		})
+		assert.ErrorContains(t, err, "invalid start-side")
+	})
+
+	t.Run("api error", func(t *testing.T) {
+		mock := &mockQuerier{
+			queryFunc: func(_ string, _ map[string]any, _ any) error {
+				return fmt.Errorf("network error")
+			},
+		}
+
+		_, err := AddThread(mock, AddThreadOptions{
+			ReviewID: "PRR_123",
+			Path:     "file.go",
+			Line:     1,
+			Body:     "comment",
+		})
+		assert.ErrorContains(t, err, "add review thread")
+		assert.ErrorContains(t, err, "network error")
+	})
+}
+
+func TestPrintResult(t *testing.T) {
+	var buf bytes.Buffer
+	err := PrintResult(&AddThreadResult{ThreadID: "PRRT_abc"}, &buf)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"threadId":"PRRT_abc"}`, buf.String())
+}
+
+func TestReadBodyFile(t *testing.T) {
+	t.Run("valid file", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "body.txt")
+		require.NoError(t, os.WriteFile(path, []byte("hello world"), 0o644))
+
+		content, err := ReadBodyFile(path)
+		require.NoError(t, err)
+		assert.Equal(t, "hello world", content)
+	})
+
+	t.Run("missing file", func(t *testing.T) {
+		_, err := ReadBodyFile("/nonexistent/body.txt")
+		assert.ErrorContains(t, err, "read body file")
+	})
+}


### PR DESCRIPTION
## Summary
- Implements #9 — `review thread add` command for inline PR review comments
- GraphQL `addPullRequestReviewThread` mutation with single/multi-line support
- `--body`/`--body-file` mutually exclusive, LEFT/RIGHT side validation

## Test plan
- [x] Unit tests (9 cases) pass
- [ ] Manual test: create pending review, add thread, verify output

🤖 Generated with [Claude Code](https://claude.com/claude-code)