### PR TITLE
feat: add `review submit` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `gh cherry issue types` command to list available issue types for a repository
 - `gh cherry pr diff` command with annotated L/R line numbers for AI agent review workflows
 - `gh cherry review start` command to create or reuse a pending PR review via GraphQL
+- `gh cherry review submit` command to submit a pending review with APPROVE/REQUEST_CHANGES/COMMENT
 - `ghcli.Querier` interface for mockable GraphQL operations
 - `ghcli.RESTQuerier` interface for mockable REST operations
 - Pre-commit hooks via prek (gofumpt, golangci-lint, typos)

--- a/cmd/review.go
+++ b/cmd/review.go
@@ -26,11 +26,26 @@ func init() {
 	reviewStartCmd.Flags().StringP("repo", "R", "", "Repository in owner/repo format")
 	reviewStartCmd.MarkFlagsMutuallyExclusive("body", "body-file")
 
+	reviewSubmitCmd := &cobra.Command{
+		Use:   "submit <review-id>",
+		Short: "Submit a pending review",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runReviewSubmit(cmd, args)
+		},
+	}
+	reviewSubmitCmd.Flags().StringP("event", "e", "", "Review event: APPROVE, REQUEST_CHANGES, or COMMENT")
+	reviewSubmitCmd.Flags().StringP("body", "b", "", "Summary text")
+	reviewSubmitCmd.Flags().String("body-file", "", "Read summary from file")
+	_ = reviewSubmitCmd.MarkFlagRequired("event")
+	reviewSubmitCmd.MarkFlagsMutuallyExclusive("body", "body-file")
+
 	reviewCmd := &cobra.Command{
 		Use:   "review",
 		Short: "PR review operations",
 	}
 	reviewCmd.AddCommand(reviewStartCmd)
+	reviewCmd.AddCommand(reviewSubmitCmd)
 	rootCmd.AddCommand(reviewCmd)
 }
 
@@ -63,6 +78,27 @@ func runReviewStart(cmd *cobra.Command, args []string) error {
 
 	if result.Reused && body != "" {
 		fmt.Fprintln(os.Stderr, "warning: --body ignored, reusing existing pending review")
+	}
+
+	return json.NewEncoder(os.Stdout).Encode(result)
+}
+
+func runReviewSubmit(cmd *cobra.Command, args []string) error {
+	event, _ := cmd.Flags().GetString("event")
+
+	body, err := resolveBody(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := ghcli.NewClient()
+	if err != nil {
+		return err
+	}
+
+	result, err := review.SubmitReview(client, args[0], event, body)
+	if err != nil {
+		return err
 	}
 
 	return json.NewEncoder(os.Stdout).Encode(result)

--- a/internal/review/submit.go
+++ b/internal/review/submit.go
@@ -1,0 +1,67 @@
+package review
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/EurFelux/gh-cherry/internal/ghcli"
+)
+
+// ValidEvents contains the allowed values for the review event parameter.
+var ValidEvents = []string{"APPROVE", "REQUEST_CHANGES", "COMMENT"}
+
+// SubmitResult holds the outcome of submitting a pending review.
+type SubmitResult struct {
+	ID    string `json:"id"`
+	State string `json:"state"`
+}
+
+// SubmitReview submits a pending pull request review with the given event type.
+func SubmitReview(client ghcli.Querier, reviewID, event, body string) (*SubmitResult, error) {
+	if err := validateEvent(event); err != nil {
+		return nil, err
+	}
+
+	query := `mutation($reviewId: ID!, $event: PullRequestReviewEvent!, $body: String) {
+		submitPullRequestReview(input: { pullRequestReviewId: $reviewId, event: $event, body: $body }) {
+			pullRequestReview {
+				id
+				state
+			}
+		}
+	}`
+
+	vars := map[string]any{
+		"reviewId": reviewID,
+		"event":    event,
+	}
+	if body != "" {
+		vars["body"] = body
+	}
+
+	var result struct {
+		SubmitPullRequestReview struct {
+			PullRequestReview struct {
+				ID    string `json:"id"`
+				State string `json:"state"`
+			} `json:"pullRequestReview"`
+		} `json:"submitPullRequestReview"`
+	}
+
+	if err := client.Query(query, vars, &result); err != nil {
+		return nil, fmt.Errorf("submit review: %w", err)
+	}
+
+	pr := result.SubmitPullRequestReview.PullRequestReview
+	return &SubmitResult{
+		ID:    pr.ID,
+		State: pr.State,
+	}, nil
+}
+
+func validateEvent(event string) error {
+	if !slices.Contains(ValidEvents, event) {
+		return fmt.Errorf("invalid event %q, must be one of: APPROVE, REQUEST_CHANGES, COMMENT", event)
+	}
+	return nil
+}

--- a/internal/review/submit_test.go
+++ b/internal/review/submit_test.go
@@ -1,0 +1,99 @@
+package review
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// submitResp matches the anonymous struct type used in SubmitReview.
+type submitResp = struct {
+	SubmitPullRequestReview struct {
+		PullRequestReview struct {
+			ID    string `json:"id"`
+			State string `json:"state"`
+		} `json:"pullRequestReview"`
+	} `json:"submitPullRequestReview"`
+}
+
+func setSubmitResult(result any, id, state string) {
+	r := result.(*submitResp)
+	r.SubmitPullRequestReview.PullRequestReview.ID = id
+	r.SubmitPullRequestReview.PullRequestReview.State = state
+}
+
+func TestSubmitReview(t *testing.T) {
+	t.Run("approve", func(t *testing.T) {
+		mock := &mockQuerier{
+			queryFunc: func(query string, variables map[string]any, result any) error {
+				assert.Contains(t, query, "submitPullRequestReview")
+				assert.Equal(t, "PRR_123", variables["reviewId"])
+				assert.Equal(t, "APPROVE", variables["event"])
+				assert.Equal(t, "LGTM", variables["body"])
+				setSubmitResult(result, "PRR_123", "APPROVED")
+				return nil
+			},
+		}
+
+		got, err := SubmitReview(mock, "PRR_123", "APPROVE", "LGTM")
+		require.NoError(t, err)
+		assert.Equal(t, "PRR_123", got.ID)
+		assert.Equal(t, "APPROVED", got.State)
+	})
+
+	t.Run("request changes", func(t *testing.T) {
+		mock := &mockQuerier{
+			queryFunc: func(_ string, variables map[string]any, result any) error {
+				assert.Equal(t, "REQUEST_CHANGES", variables["event"])
+				setSubmitResult(result, "PRR_456", "CHANGES_REQUESTED")
+				return nil
+			},
+		}
+
+		got, err := SubmitReview(mock, "PRR_456", "REQUEST_CHANGES", "Please fix")
+		require.NoError(t, err)
+		assert.Equal(t, "CHANGES_REQUESTED", got.State)
+	})
+
+	t.Run("comment without body", func(t *testing.T) {
+		mock := &mockQuerier{
+			queryFunc: func(_ string, variables map[string]any, result any) error {
+				assert.Equal(t, "COMMENT", variables["event"])
+				_, hasBody := variables["body"]
+				assert.False(t, hasBody, "body should be omitted when empty")
+				setSubmitResult(result, "PRR_789", "COMMENTED")
+				return nil
+			},
+		}
+
+		got, err := SubmitReview(mock, "PRR_789", "COMMENT", "")
+		require.NoError(t, err)
+		assert.Equal(t, "COMMENTED", got.State)
+	})
+
+	t.Run("invalid event", func(t *testing.T) {
+		mock := &mockQuerier{
+			queryFunc: func(_ string, _ map[string]any, _ any) error {
+				t.Fatal("should not be called")
+				return nil
+			},
+		}
+
+		_, err := SubmitReview(mock, "PRR_123", "INVALID", "")
+		assert.ErrorContains(t, err, `invalid event "INVALID"`)
+	})
+
+	t.Run("api error", func(t *testing.T) {
+		mock := &mockQuerier{
+			queryFunc: func(_ string, _ map[string]any, _ any) error {
+				return fmt.Errorf("forbidden")
+			},
+		}
+
+		_, err := SubmitReview(mock, "PRR_123", "APPROVE", "")
+		assert.ErrorContains(t, err, "submit review")
+		assert.ErrorContains(t, err, "forbidden")
+	})
+}


### PR DESCRIPTION
## Summary
- Adds `gh cherry review submit <review-id> --event APPROVE|REQUEST_CHANGES|COMMENT` to submit pending PR reviews
- Validates event values client-side before calling the `submitPullRequestReview` GraphQL mutation
- Supports optional `--body`/`--body-file` flags for review summary text
- Returns JSON output with review ID and final state

Fixes #5

## Test plan
- [x] Unit tests for all event types (APPROVE, REQUEST_CHANGES, COMMENT)
- [x] Unit test for empty body omission
- [x] Unit test for invalid event validation
- [x] Unit test for API error propagation
- [x] `golangci-lint run` passes with 0 issues
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)