### PR TITLE
feat: add `review preview` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `gh cherry pr diff` command with annotated L/R line numbers for AI agent review workflows
 - `gh cherry review start` command to create or reuse a pending PR review via GraphQL
 - `gh cherry review submit` command to submit a pending review with APPROVE/REQUEST_CHANGES/COMMENT
+- `gh cherry review preview` command to preview pending review comments before submitting
 - `ghcli.Querier` interface for mockable GraphQL operations
 - `ghcli.RESTQuerier` interface for mockable REST operations
 - Pre-commit hooks via prek (gofumpt, golangci-lint, typos)

--- a/cmd/review.go
+++ b/cmd/review.go
@@ -40,12 +40,22 @@ func init() {
 	_ = reviewSubmitCmd.MarkFlagRequired("event")
 	reviewSubmitCmd.MarkFlagsMutuallyExclusive("body", "body-file")
 
+	reviewPreviewCmd := &cobra.Command{
+		Use:   "preview <review-id>",
+		Short: "Preview a pending review's comments before submitting",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			return runReviewPreview(args)
+		},
+	}
+
 	reviewCmd := &cobra.Command{
 		Use:   "review",
 		Short: "PR review operations",
 	}
 	reviewCmd.AddCommand(reviewStartCmd)
 	reviewCmd.AddCommand(reviewSubmitCmd)
+	reviewCmd.AddCommand(reviewPreviewCmd)
 	rootCmd.AddCommand(reviewCmd)
 }
 
@@ -97,6 +107,20 @@ func runReviewSubmit(cmd *cobra.Command, args []string) error {
 	}
 
 	result, err := review.SubmitReview(client, args[0], event, body)
+	if err != nil {
+		return err
+	}
+
+	return json.NewEncoder(os.Stdout).Encode(result)
+}
+
+func runReviewPreview(args []string) error {
+	client, err := ghcli.NewClient()
+	if err != nil {
+		return err
+	}
+
+	result, err := review.PreviewReview(client, args[0])
 	if err != nil {
 		return err
 	}

--- a/internal/review/preview.go
+++ b/internal/review/preview.go
@@ -1,0 +1,87 @@
+package review
+
+import (
+	"fmt"
+
+	"github.com/EurFelux/gh-cherry/internal/ghcli"
+)
+
+// PreviewComment represents a single comment in a pending review.
+type PreviewComment struct {
+	ID   string `json:"id"`
+	Path string `json:"path"`
+	Line int    `json:"line"`
+	Body string `json:"body"`
+}
+
+// PreviewResult holds the preview of a pending review.
+type PreviewResult struct {
+	ID       string           `json:"id"`
+	State    string           `json:"state"`
+	Body     string           `json:"body,omitempty"`
+	Comments []PreviewComment `json:"comments"`
+}
+
+// PreviewReview fetches a review node and its pending comments for preview.
+func PreviewReview(client ghcli.Querier, reviewID string) (*PreviewResult, error) {
+	query := `query($id: ID!) {
+		node(id: $id) {
+			... on PullRequestReview {
+				id
+				state
+				body
+				comments(first: 100) {
+					nodes {
+						id
+						path
+						originalLine
+						body
+					}
+				}
+			}
+		}
+	}`
+
+	var result struct {
+		Node struct {
+			ID    string `json:"id"`
+			State string `json:"state"`
+			Body  string `json:"body"`
+
+			Comments struct {
+				Nodes []struct {
+					ID           string `json:"id"`
+					Path         string `json:"path"`
+					OriginalLine int    `json:"originalLine"`
+					Body         string `json:"body"`
+				} `json:"nodes"`
+			} `json:"comments"`
+		} `json:"node"`
+	}
+
+	if err := client.Query(query, map[string]any{"id": reviewID}, &result); err != nil {
+		return nil, fmt.Errorf("preview review: %w", err)
+	}
+
+	node := result.Node
+	if node.ID == "" {
+		return nil, fmt.Errorf("review %q not found", reviewID)
+	}
+
+	comments := make([]PreviewComment, len(node.Comments.Nodes))
+	for i, c := range node.Comments.Nodes {
+		comments[i] = PreviewComment{
+			ID:   c.ID,
+			Path: c.Path,
+			Line: c.OriginalLine,
+			Body: c.Body,
+		}
+	}
+
+	return &PreviewResult{
+		ID:       node.ID,
+		State:    node.State,
+		Body:     node.Body,
+		Comments: comments,
+	}, nil
+}

--- a/internal/review/preview_test.go
+++ b/internal/review/preview_test.go
@@ -1,0 +1,103 @@
+package review
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// previewResp matches the anonymous struct type used in PreviewReview.
+type previewResp = struct {
+	Node struct {
+		ID    string `json:"id"`
+		State string `json:"state"`
+		Body  string `json:"body"`
+
+		Comments struct {
+			Nodes []struct {
+				ID           string `json:"id"`
+				Path         string `json:"path"`
+				OriginalLine int    `json:"originalLine"`
+				Body         string `json:"body"`
+			} `json:"nodes"`
+		} `json:"comments"`
+	} `json:"node"`
+}
+
+func TestPreviewReview(t *testing.T) {
+	t.Run("review with comments", func(t *testing.T) {
+		mock := &mockQuerier{
+			queryFunc: func(query string, variables map[string]any, result any) error {
+				assert.Contains(t, query, "PullRequestReview")
+				assert.Equal(t, "PRR_123", variables["id"])
+
+				r := result.(*previewResp)
+				r.Node.ID = "PRR_123"
+				r.Node.State = "PENDING"
+				r.Node.Body = "Overall looks good"
+				r.Node.Comments.Nodes = []struct {
+					ID           string `json:"id"`
+					Path         string `json:"path"`
+					OriginalLine int    `json:"originalLine"`
+					Body         string `json:"body"`
+				}{
+					{ID: "PRRC_1", Path: "src/main.go", OriginalLine: 42, Body: "Fix this"},
+					{ID: "PRRC_2", Path: "src/util.go", OriginalLine: 10, Body: "Rename this"},
+				}
+				return nil
+			},
+		}
+
+		got, err := PreviewReview(mock, "PRR_123")
+		require.NoError(t, err)
+		assert.Equal(t, "PRR_123", got.ID)
+		assert.Equal(t, "PENDING", got.State)
+		assert.Equal(t, "Overall looks good", got.Body)
+		require.Len(t, got.Comments, 2)
+		assert.Equal(t, "PRRC_1", got.Comments[0].ID)
+		assert.Equal(t, "src/main.go", got.Comments[0].Path)
+		assert.Equal(t, 42, got.Comments[0].Line)
+		assert.Equal(t, "Fix this", got.Comments[0].Body)
+	})
+
+	t.Run("review with no comments", func(t *testing.T) {
+		mock := &mockQuerier{
+			queryFunc: func(_ string, _ map[string]any, result any) error {
+				r := result.(*previewResp)
+				r.Node.ID = "PRR_456"
+				r.Node.State = "PENDING"
+				return nil
+			},
+		}
+
+		got, err := PreviewReview(mock, "PRR_456")
+		require.NoError(t, err)
+		assert.Equal(t, "PRR_456", got.ID)
+		assert.Empty(t, got.Comments)
+	})
+
+	t.Run("review not found", func(t *testing.T) {
+		mock := &mockQuerier{
+			queryFunc: func(_ string, _ map[string]any, _ any) error {
+				return nil
+			},
+		}
+
+		_, err := PreviewReview(mock, "PRR_nonexistent")
+		assert.ErrorContains(t, err, "not found")
+	})
+
+	t.Run("api error", func(t *testing.T) {
+		mock := &mockQuerier{
+			queryFunc: func(_ string, _ map[string]any, _ any) error {
+				return fmt.Errorf("network error")
+			},
+		}
+
+		_, err := PreviewReview(mock, "PRR_123")
+		assert.ErrorContains(t, err, "preview review")
+		assert.ErrorContains(t, err, "network error")
+	})
+}


### PR DESCRIPTION
## Summary
- Adds `gh cherry review preview <review-id>` to preview a pending review's body and comments before submitting
- Uses the GraphQL `node(id)` interface query with `... on PullRequestReview` to fetch review details
- Returns JSON with review ID, state, body, and all pending comments (path, line, body)

Fixes #6

## Test plan
- [x] Unit test for review with comments (verifies all fields mapped correctly)
- [x] Unit test for review with no comments
- [x] Unit test for review not found
- [x] Unit test for API error propagation
- [x] `golangci-lint run` passes with 0 issues
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)