### PR TITLE
feat: add `review view` command for PR reviews and threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `gh cherry review start` command to create or reuse a pending PR review via GraphQL
 - `gh cherry review submit` command to submit a pending review with APPROVE/REQUEST_CHANGES/COMMENT
 - `gh cherry review preview` command to preview pending review comments before submitting
+- `gh cherry review view` command to view all reviews and threads for a PR with filtering
 - `ghcli.Querier` interface for mockable GraphQL operations
 - `ghcli.RESTQuerier` interface for mockable REST operations
 - Pre-commit hooks via prek (gofumpt, golangci-lint, typos)

--- a/cmd/review.go
+++ b/cmd/review.go
@@ -40,6 +40,20 @@ func init() {
 	_ = reviewSubmitCmd.MarkFlagRequired("event")
 	reviewSubmitCmd.MarkFlagsMutuallyExclusive("body", "body-file")
 
+	reviewViewCmd := &cobra.Command{
+		Use:   "view <pr-number>",
+		Short: "View all reviews and threads for a pull request",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runReviewView(cmd, args)
+		},
+	}
+	reviewViewCmd.Flags().String("reviewer", "", "Filter by reviewer login")
+	reviewViewCmd.Flags().String("state", "", "Filter by review state")
+	reviewViewCmd.Flags().Bool("unresolved", false, "Only show unresolved threads")
+	reviewViewCmd.Flags().Int("tail", 0, "Show only last N comments per thread")
+	reviewViewCmd.Flags().StringP("repo", "R", "", "Repository in owner/repo format")
+
 	reviewPreviewCmd := &cobra.Command{
 		Use:   "preview <review-id>",
 		Short: "Preview a pending review's comments before submitting",
@@ -55,6 +69,7 @@ func init() {
 	}
 	reviewCmd.AddCommand(reviewStartCmd)
 	reviewCmd.AddCommand(reviewSubmitCmd)
+	reviewCmd.AddCommand(reviewViewCmd)
 	reviewCmd.AddCommand(reviewPreviewCmd)
 	rootCmd.AddCommand(reviewCmd)
 }
@@ -107,6 +122,44 @@ func runReviewSubmit(cmd *cobra.Command, args []string) error {
 	}
 
 	result, err := review.SubmitReview(client, args[0], event, body)
+	if err != nil {
+		return err
+	}
+
+	return json.NewEncoder(os.Stdout).Encode(result)
+}
+
+func runReviewView(cmd *cobra.Command, args []string) error {
+	prNumber, err := strconv.Atoi(args[0])
+	if err != nil {
+		return fmt.Errorf("invalid PR number %q: %w", args[0], err)
+	}
+
+	repo, _ := cmd.Flags().GetString("repo")
+	owner, repoName, err := issue.ResolveRepo(repo)
+	if err != nil {
+		return err
+	}
+
+	reviewer, _ := cmd.Flags().GetString("reviewer")
+	state, _ := cmd.Flags().GetString("state")
+	unresolved, _ := cmd.Flags().GetBool("unresolved")
+	tail, _ := cmd.Flags().GetInt("tail")
+
+	client, err := ghcli.NewClient()
+	if err != nil {
+		return err
+	}
+
+	result, err := review.ViewReviews(client, review.ViewOptions{
+		Owner:      owner,
+		Repo:       repoName,
+		PRNumber:   prNumber,
+		Reviewer:   reviewer,
+		State:      state,
+		Unresolved: unresolved,
+		Tail:       tail,
+	})
 	if err != nil {
 		return err
 	}

--- a/internal/review/view.go
+++ b/internal/review/view.go
@@ -1,0 +1,283 @@
+package review
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/EurFelux/gh-cherry/internal/ghcli"
+)
+
+// ViewOptions holds the filter options for viewing reviews and threads.
+type ViewOptions struct {
+	Owner      string
+	Repo       string
+	PRNumber   int
+	Reviewer   string
+	State      string
+	Unresolved bool
+	Tail       int
+}
+
+// ViewReview represents a single review in the view output.
+type ViewReview struct {
+	ID          string `json:"id"`
+	Author      string `json:"author"`
+	State       string `json:"state"`
+	Body        string `json:"body,omitempty"`
+	SubmittedAt string `json:"submittedAt,omitempty"`
+}
+
+// ViewThreadComment represents a comment within a review thread.
+type ViewThreadComment struct {
+	ID        string `json:"id"`
+	Author    string `json:"author"`
+	Body      string `json:"body"`
+	CreatedAt string `json:"createdAt"`
+}
+
+// ViewThread represents a review thread in the view output.
+type ViewThread struct {
+	ID         string              `json:"id"`
+	Path       string              `json:"path"`
+	Line       int                 `json:"line"`
+	IsResolved bool                `json:"isResolved"`
+	Comments   []ViewThreadComment `json:"comments"`
+}
+
+// ViewResult holds the complete view of reviews and threads for a PR.
+type ViewResult struct {
+	Reviews []ViewReview `json:"reviews"`
+	Threads []ViewThread `json:"threads"`
+}
+
+// ViewReviews fetches all reviews and review threads for a PR with optional filtering.
+func ViewReviews(client ghcli.Querier, opts ViewOptions) (*ViewResult, error) {
+	reviews, err := fetchAllReviews(client, opts.Owner, opts.Repo, opts.PRNumber)
+	if err != nil {
+		return nil, fmt.Errorf("fetch reviews: %w", err)
+	}
+
+	threads, err := fetchAllThreads(client, opts.Owner, opts.Repo, opts.PRNumber)
+	if err != nil {
+		return nil, fmt.Errorf("fetch threads: %w", err)
+	}
+
+	reviews = filterReviews(reviews, opts)
+	threads = filterThreads(threads, opts)
+
+	return &ViewResult{
+		Reviews: reviews,
+		Threads: threads,
+	}, nil
+}
+
+func fetchAllReviews(client ghcli.Querier, owner, repo string, prNumber int) ([]ViewReview, error) {
+	query := `query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
+		repository(owner: $owner, name: $repo) {
+			pullRequest(number: $number) {
+				reviews(first: 100, after: $cursor) {
+					nodes {
+						id
+						author { login }
+						state
+						body
+						submittedAt
+					}
+					pageInfo {
+						hasNextPage
+						endCursor
+					}
+				}
+			}
+		}
+	}`
+
+	var allReviews []ViewReview
+	var cursor *string
+
+	for {
+		vars := map[string]any{
+			"owner":  owner,
+			"repo":   repo,
+			"number": prNumber,
+		}
+		if cursor != nil {
+			vars["cursor"] = *cursor
+		}
+
+		var result struct {
+			Repository struct {
+				PullRequest struct {
+					Reviews struct {
+						Nodes []struct {
+							ID     string `json:"id"`
+							Author struct {
+								Login string `json:"login"`
+							} `json:"author"`
+							State       string `json:"state"`
+							Body        string `json:"body"`
+							SubmittedAt string `json:"submittedAt"`
+						} `json:"nodes"`
+						PageInfo struct {
+							HasNextPage bool   `json:"hasNextPage"`
+							EndCursor   string `json:"endCursor"`
+						} `json:"pageInfo"`
+					} `json:"reviews"`
+				} `json:"pullRequest"`
+			} `json:"repository"`
+		}
+
+		if err := client.Query(query, vars, &result); err != nil {
+			return nil, err
+		}
+
+		for _, n := range result.Repository.PullRequest.Reviews.Nodes {
+			allReviews = append(allReviews, ViewReview{
+				ID:          n.ID,
+				Author:      n.Author.Login,
+				State:       n.State,
+				Body:        n.Body,
+				SubmittedAt: n.SubmittedAt,
+			})
+		}
+
+		pi := result.Repository.PullRequest.Reviews.PageInfo
+		if !pi.HasNextPage {
+			break
+		}
+		cursor = &pi.EndCursor
+	}
+
+	return allReviews, nil
+}
+
+func fetchAllThreads(client ghcli.Querier, owner, repo string, prNumber int) ([]ViewThread, error) {
+	query := `query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
+		repository(owner: $owner, name: $repo) {
+			pullRequest(number: $number) {
+				reviewThreads(first: 100, after: $cursor) {
+					nodes {
+						id
+						path
+						line
+						isResolved
+						comments(first: 100) {
+							nodes {
+								id
+								author { login }
+								body
+								createdAt
+							}
+						}
+					}
+					pageInfo {
+						hasNextPage
+						endCursor
+					}
+				}
+			}
+		}
+	}`
+
+	var allThreads []ViewThread
+	var cursor *string
+
+	for {
+		vars := map[string]any{
+			"owner":  owner,
+			"repo":   repo,
+			"number": prNumber,
+		}
+		if cursor != nil {
+			vars["cursor"] = *cursor
+		}
+
+		var result struct {
+			Repository struct {
+				PullRequest struct {
+					ReviewThreads struct {
+						Nodes []struct {
+							ID         string `json:"id"`
+							Path       string `json:"path"`
+							Line       int    `json:"line"`
+							IsResolved bool   `json:"isResolved"`
+							Comments   struct {
+								Nodes []struct {
+									ID     string `json:"id"`
+									Author struct {
+										Login string `json:"login"`
+									} `json:"author"`
+									Body      string `json:"body"`
+									CreatedAt string `json:"createdAt"`
+								} `json:"nodes"`
+							} `json:"comments"`
+						} `json:"nodes"`
+						PageInfo struct {
+							HasNextPage bool   `json:"hasNextPage"`
+							EndCursor   string `json:"endCursor"`
+						} `json:"pageInfo"`
+					} `json:"reviewThreads"`
+				} `json:"pullRequest"`
+			} `json:"repository"`
+		}
+
+		if err := client.Query(query, vars, &result); err != nil {
+			return nil, err
+		}
+
+		for _, n := range result.Repository.PullRequest.ReviewThreads.Nodes {
+			comments := make([]ViewThreadComment, len(n.Comments.Nodes))
+			for i, c := range n.Comments.Nodes {
+				comments[i] = ViewThreadComment{
+					ID:        c.ID,
+					Author:    c.Author.Login,
+					Body:      c.Body,
+					CreatedAt: c.CreatedAt,
+				}
+			}
+			allThreads = append(allThreads, ViewThread{
+				ID:         n.ID,
+				Path:       n.Path,
+				Line:       n.Line,
+				IsResolved: n.IsResolved,
+				Comments:   comments,
+			})
+		}
+
+		pi := result.Repository.PullRequest.ReviewThreads.PageInfo
+		if !pi.HasNextPage {
+			break
+		}
+		cursor = &pi.EndCursor
+	}
+
+	return allThreads, nil
+}
+
+func filterReviews(reviews []ViewReview, opts ViewOptions) []ViewReview {
+	var filtered []ViewReview
+	for _, r := range reviews {
+		if opts.Reviewer != "" && !strings.EqualFold(r.Author, opts.Reviewer) {
+			continue
+		}
+		if opts.State != "" && !strings.EqualFold(r.State, opts.State) {
+			continue
+		}
+		filtered = append(filtered, r)
+	}
+	return filtered
+}
+
+func filterThreads(threads []ViewThread, opts ViewOptions) []ViewThread {
+	var filtered []ViewThread
+	for _, t := range threads {
+		if opts.Unresolved && t.IsResolved {
+			continue
+		}
+		if opts.Tail > 0 && len(t.Comments) > opts.Tail {
+			t.Comments = t.Comments[len(t.Comments)-opts.Tail:]
+		}
+		filtered = append(filtered, t)
+	}
+	return filtered
+}

--- a/internal/review/view_test.go
+++ b/internal/review/view_test.go
@@ -1,0 +1,405 @@
+package review
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// reviewsResp matches the anonymous struct for fetchAllReviews.
+type reviewsResp = struct {
+	Repository struct {
+		PullRequest struct {
+			Reviews struct {
+				Nodes []struct {
+					ID     string `json:"id"`
+					Author struct {
+						Login string `json:"login"`
+					} `json:"author"`
+					State       string `json:"state"`
+					Body        string `json:"body"`
+					SubmittedAt string `json:"submittedAt"`
+				} `json:"nodes"`
+				PageInfo struct {
+					HasNextPage bool   `json:"hasNextPage"`
+					EndCursor   string `json:"endCursor"`
+				} `json:"pageInfo"`
+			} `json:"reviews"`
+		} `json:"pullRequest"`
+	} `json:"repository"`
+}
+
+// threadsResp matches the anonymous struct for fetchAllThreads.
+type threadsResp = struct {
+	Repository struct {
+		PullRequest struct {
+			ReviewThreads struct {
+				Nodes []struct {
+					ID         string `json:"id"`
+					Path       string `json:"path"`
+					Line       int    `json:"line"`
+					IsResolved bool   `json:"isResolved"`
+					Comments   struct {
+						Nodes []struct {
+							ID     string `json:"id"`
+							Author struct {
+								Login string `json:"login"`
+							} `json:"author"`
+							Body      string `json:"body"`
+							CreatedAt string `json:"createdAt"`
+						} `json:"nodes"`
+					} `json:"comments"`
+				} `json:"nodes"`
+				PageInfo struct {
+					HasNextPage bool   `json:"hasNextPage"`
+					EndCursor   string `json:"endCursor"`
+				} `json:"pageInfo"`
+			} `json:"reviewThreads"`
+		} `json:"pullRequest"`
+	} `json:"repository"`
+}
+
+func TestViewReviews(t *testing.T) {
+	t.Run("basic view with reviews and threads", func(t *testing.T) {
+		calls := 0
+		mock := &mockQuerier{
+			queryFunc: func(_ string, variables map[string]any, result any) error {
+				calls++
+				if calls == 1 {
+					// reviews query
+					assert.Equal(t, "owner", variables["owner"])
+					assert.Equal(t, "repo", variables["repo"])
+					assert.Equal(t, 42, variables["number"])
+
+					r := result.(*reviewsResp)
+					r.Repository.PullRequest.Reviews.Nodes = []struct {
+						ID     string `json:"id"`
+						Author struct {
+							Login string `json:"login"`
+						} `json:"author"`
+						State       string `json:"state"`
+						Body        string `json:"body"`
+						SubmittedAt string `json:"submittedAt"`
+					}{
+						{ID: "PRR_1", Author: struct {
+							Login string `json:"login"`
+						}{Login: "alice"}, State: "APPROVED", Body: "LGTM", SubmittedAt: "2024-01-01T00:00:00Z"},
+					}
+					return nil
+				}
+				// threads query
+				r := result.(*threadsResp)
+				r.Repository.PullRequest.ReviewThreads.Nodes = []struct {
+					ID         string `json:"id"`
+					Path       string `json:"path"`
+					Line       int    `json:"line"`
+					IsResolved bool   `json:"isResolved"`
+					Comments   struct {
+						Nodes []struct {
+							ID     string `json:"id"`
+							Author struct {
+								Login string `json:"login"`
+							} `json:"author"`
+							Body      string `json:"body"`
+							CreatedAt string `json:"createdAt"`
+						} `json:"nodes"`
+					} `json:"comments"`
+				}{
+					{
+						ID: "PRRT_1", Path: "main.go", Line: 10, IsResolved: false,
+						Comments: struct {
+							Nodes []struct {
+								ID     string `json:"id"`
+								Author struct {
+									Login string `json:"login"`
+								} `json:"author"`
+								Body      string `json:"body"`
+								CreatedAt string `json:"createdAt"`
+							} `json:"nodes"`
+						}{
+							Nodes: []struct {
+								ID     string `json:"id"`
+								Author struct {
+									Login string `json:"login"`
+								} `json:"author"`
+								Body      string `json:"body"`
+								CreatedAt string `json:"createdAt"`
+							}{
+								{ID: "PRRC_1", Author: struct {
+									Login string `json:"login"`
+								}{Login: "bob"}, Body: "Fix this", CreatedAt: "2024-01-01T00:00:00Z"},
+							},
+						},
+					},
+				}
+				return nil
+			},
+		}
+
+		got, err := ViewReviews(mock, ViewOptions{
+			Owner:    "owner",
+			Repo:     "repo",
+			PRNumber: 42,
+		})
+		require.NoError(t, err)
+		require.Len(t, got.Reviews, 1)
+		assert.Equal(t, "PRR_1", got.Reviews[0].ID)
+		assert.Equal(t, "alice", got.Reviews[0].Author)
+		assert.Equal(t, "APPROVED", got.Reviews[0].State)
+		require.Len(t, got.Threads, 1)
+		assert.Equal(t, "PRRT_1", got.Threads[0].ID)
+		assert.False(t, got.Threads[0].IsResolved)
+		require.Len(t, got.Threads[0].Comments, 1)
+		assert.Equal(t, "bob", got.Threads[0].Comments[0].Author)
+	})
+
+	t.Run("filter by reviewer", func(t *testing.T) {
+		calls := 0
+		mock := &mockQuerier{
+			queryFunc: func(_ string, _ map[string]any, result any) error {
+				calls++
+				if calls == 1 {
+					r := result.(*reviewsResp)
+					r.Repository.PullRequest.Reviews.Nodes = []struct {
+						ID     string `json:"id"`
+						Author struct {
+							Login string `json:"login"`
+						} `json:"author"`
+						State       string `json:"state"`
+						Body        string `json:"body"`
+						SubmittedAt string `json:"submittedAt"`
+					}{
+						{ID: "PRR_1", Author: struct {
+							Login string `json:"login"`
+						}{Login: "alice"}, State: "APPROVED"},
+						{ID: "PRR_2", Author: struct {
+							Login string `json:"login"`
+						}{Login: "bob"}, State: "CHANGES_REQUESTED"},
+					}
+					return nil
+				}
+				return nil
+			},
+		}
+
+		got, err := ViewReviews(mock, ViewOptions{
+			Owner: "o", Repo: "r", PRNumber: 1,
+			Reviewer: "alice",
+		})
+		require.NoError(t, err)
+		require.Len(t, got.Reviews, 1)
+		assert.Equal(t, "alice", got.Reviews[0].Author)
+	})
+
+	t.Run("filter by state", func(t *testing.T) {
+		calls := 0
+		mock := &mockQuerier{
+			queryFunc: func(_ string, _ map[string]any, result any) error {
+				calls++
+				if calls == 1 {
+					r := result.(*reviewsResp)
+					r.Repository.PullRequest.Reviews.Nodes = []struct {
+						ID     string `json:"id"`
+						Author struct {
+							Login string `json:"login"`
+						} `json:"author"`
+						State       string `json:"state"`
+						Body        string `json:"body"`
+						SubmittedAt string `json:"submittedAt"`
+					}{
+						{ID: "PRR_1", State: "APPROVED"},
+						{ID: "PRR_2", State: "CHANGES_REQUESTED"},
+					}
+					return nil
+				}
+				return nil
+			},
+		}
+
+		got, err := ViewReviews(mock, ViewOptions{
+			Owner: "o", Repo: "r", PRNumber: 1,
+			State: "APPROVED",
+		})
+		require.NoError(t, err)
+		require.Len(t, got.Reviews, 1)
+		assert.Equal(t, "APPROVED", got.Reviews[0].State)
+	})
+
+	t.Run("filter unresolved threads", func(t *testing.T) {
+		calls := 0
+		mock := &mockQuerier{
+			queryFunc: func(_ string, _ map[string]any, result any) error {
+				calls++
+				if calls == 1 {
+					return nil
+				}
+				r := result.(*threadsResp)
+				r.Repository.PullRequest.ReviewThreads.Nodes = []struct {
+					ID         string `json:"id"`
+					Path       string `json:"path"`
+					Line       int    `json:"line"`
+					IsResolved bool   `json:"isResolved"`
+					Comments   struct {
+						Nodes []struct {
+							ID     string `json:"id"`
+							Author struct {
+								Login string `json:"login"`
+							} `json:"author"`
+							Body      string `json:"body"`
+							CreatedAt string `json:"createdAt"`
+						} `json:"nodes"`
+					} `json:"comments"`
+				}{
+					{ID: "PRRT_1", IsResolved: false},
+					{ID: "PRRT_2", IsResolved: true},
+				}
+				return nil
+			},
+		}
+
+		got, err := ViewReviews(mock, ViewOptions{
+			Owner: "o", Repo: "r", PRNumber: 1,
+			Unresolved: true,
+		})
+		require.NoError(t, err)
+		require.Len(t, got.Threads, 1)
+		assert.Equal(t, "PRRT_1", got.Threads[0].ID)
+	})
+
+	t.Run("tail limits comments per thread", func(t *testing.T) {
+		calls := 0
+		mock := &mockQuerier{
+			queryFunc: func(_ string, _ map[string]any, result any) error {
+				calls++
+				if calls == 1 {
+					return nil
+				}
+				r := result.(*threadsResp)
+				comments := make([]struct {
+					ID     string `json:"id"`
+					Author struct {
+						Login string `json:"login"`
+					} `json:"author"`
+					Body      string `json:"body"`
+					CreatedAt string `json:"createdAt"`
+				}, 5)
+				for i := range comments {
+					comments[i].ID = fmt.Sprintf("PRRC_%d", i+1)
+					comments[i].Body = fmt.Sprintf("comment %d", i+1)
+				}
+
+				r.Repository.PullRequest.ReviewThreads.Nodes = []struct {
+					ID         string `json:"id"`
+					Path       string `json:"path"`
+					Line       int    `json:"line"`
+					IsResolved bool   `json:"isResolved"`
+					Comments   struct {
+						Nodes []struct {
+							ID     string `json:"id"`
+							Author struct {
+								Login string `json:"login"`
+							} `json:"author"`
+							Body      string `json:"body"`
+							CreatedAt string `json:"createdAt"`
+						} `json:"nodes"`
+					} `json:"comments"`
+				}{
+					{ID: "PRRT_1"},
+				}
+				r.Repository.PullRequest.ReviewThreads.Nodes[0].Comments.Nodes = comments
+				return nil
+			},
+		}
+
+		got, err := ViewReviews(mock, ViewOptions{
+			Owner: "o", Repo: "r", PRNumber: 1,
+			Tail: 2,
+		})
+		require.NoError(t, err)
+		require.Len(t, got.Threads, 1)
+		require.Len(t, got.Threads[0].Comments, 2)
+		assert.Equal(t, "PRRC_4", got.Threads[0].Comments[0].ID)
+		assert.Equal(t, "PRRC_5", got.Threads[0].Comments[1].ID)
+	})
+
+	t.Run("pagination", func(t *testing.T) {
+		calls := 0
+		mock := &mockQuerier{
+			queryFunc: func(_ string, variables map[string]any, result any) error {
+				calls++
+				switch calls {
+				case 1: // first reviews page
+					r := result.(*reviewsResp)
+					r.Repository.PullRequest.Reviews.Nodes = []struct {
+						ID     string `json:"id"`
+						Author struct {
+							Login string `json:"login"`
+						} `json:"author"`
+						State       string `json:"state"`
+						Body        string `json:"body"`
+						SubmittedAt string `json:"submittedAt"`
+					}{
+						{ID: "PRR_1", State: "APPROVED"},
+					}
+					r.Repository.PullRequest.Reviews.PageInfo.HasNextPage = true
+					r.Repository.PullRequest.Reviews.PageInfo.EndCursor = "cursor1"
+				case 2: // second reviews page
+					assert.Equal(t, "cursor1", variables["cursor"])
+					r := result.(*reviewsResp)
+					r.Repository.PullRequest.Reviews.Nodes = []struct {
+						ID     string `json:"id"`
+						Author struct {
+							Login string `json:"login"`
+						} `json:"author"`
+						State       string `json:"state"`
+						Body        string `json:"body"`
+						SubmittedAt string `json:"submittedAt"`
+					}{
+						{ID: "PRR_2", State: "COMMENTED"},
+					}
+				case 3: // threads (single page)
+					return nil
+				}
+				return nil
+			},
+		}
+
+		got, err := ViewReviews(mock, ViewOptions{
+			Owner: "o", Repo: "r", PRNumber: 1,
+		})
+		require.NoError(t, err)
+		require.Len(t, got.Reviews, 2)
+		assert.Equal(t, "PRR_1", got.Reviews[0].ID)
+		assert.Equal(t, "PRR_2", got.Reviews[1].ID)
+	})
+
+	t.Run("fetch reviews error", func(t *testing.T) {
+		mock := &mockQuerier{
+			queryFunc: func(_ string, _ map[string]any, _ any) error {
+				return fmt.Errorf("network error")
+			},
+		}
+
+		_, err := ViewReviews(mock, ViewOptions{Owner: "o", Repo: "r", PRNumber: 1})
+		assert.ErrorContains(t, err, "fetch reviews")
+	})
+
+	t.Run("fetch threads error", func(t *testing.T) {
+		calls := 0
+		mock := &mockQuerier{
+			queryFunc: func(_ string, _ map[string]any, _ any) error {
+				calls++
+				if calls == 1 {
+					return nil
+				}
+				return fmt.Errorf("timeout")
+			},
+		}
+
+		_, err := ViewReviews(mock, ViewOptions{Owner: "o", Repo: "r", PRNumber: 1})
+		assert.ErrorContains(t, err, "fetch threads")
+		assert.ErrorContains(t, err, "timeout")
+	})
+}


### PR DESCRIPTION
## Summary
- Adds `gh cherry review view <pr-number>` to fetch and display all reviews and review threads for a PR
- Supports filtering: `--reviewer` (by login), `--state` (review state), `--unresolved` (only unresolved threads), `--tail N` (last N comments per thread)
- Handles pagination for large PRs (100 items per page with cursor-based pagination)
- Returns JSON output with reviews and threads arrays

Fixes #7

## Test plan
- [x] Unit test for basic view with reviews and threads
- [x] Unit test for `--reviewer` filter
- [x] Unit test for `--state` filter
- [x] Unit test for `--unresolved` filter
- [x] Unit test for `--tail` (limits comments per thread)
- [x] Unit test for pagination across multiple pages
- [x] Unit tests for fetch reviews/threads error propagation
- [x] `golangci-lint run` passes with 0 issues
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)