### PR TITLE
feat: add `review edit` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `gh cherry review submit` command to submit a pending review with APPROVE/REQUEST_CHANGES/COMMENT
 - `gh cherry review preview` command to preview pending review comments before submitting
 - `gh cherry review view` command to view all reviews and threads for a PR with filtering
+- `gh cherry review edit` command to edit a submitted review's body text
 - `ghcli.Querier` interface for mockable GraphQL operations
 - `ghcli.RESTQuerier` interface for mockable REST operations
 - Pre-commit hooks via prek (gofumpt, golangci-lint, typos)

--- a/cmd/review.go
+++ b/cmd/review.go
@@ -54,6 +54,19 @@ func init() {
 	reviewViewCmd.Flags().Int("tail", 0, "Show only last N comments per thread")
 	reviewViewCmd.Flags().StringP("repo", "R", "", "Repository in owner/repo format")
 
+	reviewEditCmd := &cobra.Command{
+		Use:   "edit <review-id>",
+		Short: "Edit a submitted review's body text",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runReviewEdit(cmd, args)
+		},
+	}
+	reviewEditCmd.Flags().StringP("body", "b", "", "New review body")
+	reviewEditCmd.Flags().String("body-file", "", "Read body from file")
+	reviewEditCmd.MarkFlagsMutuallyExclusive("body", "body-file")
+	reviewEditCmd.MarkFlagsOneRequired("body", "body-file")
+
 	reviewPreviewCmd := &cobra.Command{
 		Use:   "preview <review-id>",
 		Short: "Preview a pending review's comments before submitting",
@@ -70,6 +83,7 @@ func init() {
 	reviewCmd.AddCommand(reviewStartCmd)
 	reviewCmd.AddCommand(reviewSubmitCmd)
 	reviewCmd.AddCommand(reviewViewCmd)
+	reviewCmd.AddCommand(reviewEditCmd)
 	reviewCmd.AddCommand(reviewPreviewCmd)
 	rootCmd.AddCommand(reviewCmd)
 }
@@ -160,6 +174,25 @@ func runReviewView(cmd *cobra.Command, args []string) error {
 		Unresolved: unresolved,
 		Tail:       tail,
 	})
+	if err != nil {
+		return err
+	}
+
+	return json.NewEncoder(os.Stdout).Encode(result)
+}
+
+func runReviewEdit(cmd *cobra.Command, args []string) error {
+	body, err := resolveBody(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := ghcli.NewClient()
+	if err != nil {
+		return err
+	}
+
+	result, err := review.EditReview(client, args[0], body)
 	if err != nil {
 		return err
 	}

--- a/internal/review/edit.go
+++ b/internal/review/edit.go
@@ -1,0 +1,44 @@
+package review
+
+import (
+	"fmt"
+
+	"github.com/EurFelux/gh-cherry/internal/ghcli"
+)
+
+// EditResult holds the outcome of editing a review's body.
+type EditResult struct {
+	ID   string `json:"id"`
+	Body string `json:"body"`
+}
+
+// EditReview updates the body text of a submitted review.
+func EditReview(client ghcli.Querier, reviewID, body string) (*EditResult, error) {
+	query := `mutation($reviewId: ID!, $body: String!) {
+		updatePullRequestReview(input: { pullRequestReviewId: $reviewId, body: $body }) {
+			pullRequestReview {
+				id
+				body
+			}
+		}
+	}`
+
+	var result struct {
+		UpdatePullRequestReview struct {
+			PullRequestReview struct {
+				ID   string `json:"id"`
+				Body string `json:"body"`
+			} `json:"pullRequestReview"`
+		} `json:"updatePullRequestReview"`
+	}
+
+	if err := client.Query(query, map[string]any{"reviewId": reviewID, "body": body}, &result); err != nil {
+		return nil, fmt.Errorf("edit review: %w", err)
+	}
+
+	pr := result.UpdatePullRequestReview.PullRequestReview
+	return &EditResult{
+		ID:   pr.ID,
+		Body: pr.Body,
+	}, nil
+}

--- a/internal/review/edit_test.go
+++ b/internal/review/edit_test.go
@@ -1,0 +1,53 @@
+package review
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// editResp matches the anonymous struct type used in EditReview.
+type editResp = struct {
+	UpdatePullRequestReview struct {
+		PullRequestReview struct {
+			ID   string `json:"id"`
+			Body string `json:"body"`
+		} `json:"pullRequestReview"`
+	} `json:"updatePullRequestReview"`
+}
+
+func TestEditReview(t *testing.T) {
+	t.Run("updates body", func(t *testing.T) {
+		mock := &mockQuerier{
+			queryFunc: func(query string, variables map[string]any, result any) error {
+				assert.Contains(t, query, "updatePullRequestReview")
+				assert.Equal(t, "PRR_123", variables["reviewId"])
+				assert.Equal(t, "Updated text", variables["body"])
+
+				r := result.(*editResp)
+				r.UpdatePullRequestReview.PullRequestReview.ID = "PRR_123"
+				r.UpdatePullRequestReview.PullRequestReview.Body = "Updated text"
+				return nil
+			},
+		}
+
+		got, err := EditReview(mock, "PRR_123", "Updated text")
+		require.NoError(t, err)
+		assert.Equal(t, "PRR_123", got.ID)
+		assert.Equal(t, "Updated text", got.Body)
+	})
+
+	t.Run("api error", func(t *testing.T) {
+		mock := &mockQuerier{
+			queryFunc: func(_ string, _ map[string]any, _ any) error {
+				return fmt.Errorf("forbidden")
+			},
+		}
+
+		_, err := EditReview(mock, "PRR_123", "text")
+		assert.ErrorContains(t, err, "edit review")
+		assert.ErrorContains(t, err, "forbidden")
+	})
+}


### PR DESCRIPTION
## Summary
- Adds `gh cherry review edit <review-id> --body "text"` to update a submitted review's body text
- Supports `--body-file` to read body from a file (mutually exclusive with `--body`, one required)
- Uses the `updatePullRequestReview` GraphQL mutation
- Returns JSON output with review ID and updated body

Fixes #8

## Test plan
- [x] Unit test for successful body update
- [x] Unit test for API error propagation
- [x] `golangci-lint run` passes with 0 issues
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)