### PR TITLE
feat: add `review thread list` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `gh cherry review thread list` command to list review threads with `--unresolved` and `--mine` filters
 - `gh cherry review thread reply` command to reply to existing review threads
 - `gh cherry issue create` command with issue type support (`-T` flag)
 - `gh cherry issue types` command to list available issue types for a repository

--- a/cmd/review.go
+++ b/cmd/review.go
@@ -96,12 +96,25 @@ func init() {
 	threadReplyCmd.MarkFlagsMutuallyExclusive("body", "body-file")
 	threadReplyCmd.MarkFlagsOneRequired("body", "body-file")
 
+	threadListCmd := &cobra.Command{
+		Use:   "list <pr-number>",
+		Short: "List review threads for a pull request",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runReviewThreadList(cmd, args)
+		},
+	}
+	threadListCmd.Flags().Bool("unresolved", false, "Only show unresolved threads")
+	threadListCmd.Flags().Bool("mine", false, "Only show threads started by me")
+	threadListCmd.Flags().StringP("repo", "R", "", "Repository in owner/repo format")
+
 	threadCmd := &cobra.Command{
 		Use:   "thread",
 		Short: "Manage review comment threads",
 	}
 	threadCmd.AddCommand(threadAddCmd)
 	threadCmd.AddCommand(threadReplyCmd)
+	threadCmd.AddCommand(threadListCmd)
 
 	reviewCmd := &cobra.Command{
 		Use:   "review",
@@ -275,6 +288,40 @@ func runReviewThreadReply(cmd *cobra.Command, args []string) error {
 	}
 
 	return json.NewEncoder(os.Stdout).Encode(result)
+}
+
+func runReviewThreadList(cmd *cobra.Command, args []string) error {
+	prNumber, err := strconv.Atoi(args[0])
+	if err != nil {
+		return fmt.Errorf("invalid PR number %q: %w", args[0], err)
+	}
+
+	repo, _ := cmd.Flags().GetString("repo")
+	owner, repoName, err := issue.ResolveRepo(repo)
+	if err != nil {
+		return err
+	}
+
+	unresolved, _ := cmd.Flags().GetBool("unresolved")
+	mine, _ := cmd.Flags().GetBool("mine")
+
+	client, err := ghcli.NewClient()
+	if err != nil {
+		return err
+	}
+
+	threads, err := review.ListThreads(client, review.ListThreadsOptions{
+		Owner:      owner,
+		Repo:       repoName,
+		PRNumber:   prNumber,
+		Unresolved: unresolved,
+		Mine:       mine,
+	})
+	if err != nil {
+		return err
+	}
+
+	return json.NewEncoder(os.Stdout).Encode(threads)
 }
 
 // resolveBody reads the review body from --body or --body-file.

--- a/internal/review/thread.go
+++ b/internal/review/thread.go
@@ -141,6 +141,182 @@ func ReplyToThread(client ghcli.Querier, opts ReplyThreadOptions) (*ReplyThreadR
 	}, nil
 }
 
+// ListThreadsOptions holds the options for listing review threads.
+type ListThreadsOptions struct {
+	Owner      string
+	Repo       string
+	PRNumber   int
+	Unresolved bool
+	Mine       bool
+}
+
+// ThreadInfo represents a review thread in the list output.
+type ThreadInfo struct {
+	ID           string       `json:"id"`
+	Path         string       `json:"path"`
+	Line         int          `json:"line"`
+	IsResolved   bool         `json:"isResolved"`
+	CommentCount int          `json:"commentCount"`
+	FirstComment FirstComment `json:"firstComment"`
+}
+
+// FirstComment represents the first comment in a thread.
+type FirstComment struct {
+	Author string `json:"author"`
+	Body   string `json:"body"`
+}
+
+// ListThreads lists all review threads for a pull request.
+func ListThreads(client ghcli.Querier, opts ListThreadsOptions) ([]ThreadInfo, error) {
+	var viewer string
+	if opts.Mine {
+		v, err := fetchViewer(client)
+		if err != nil {
+			return nil, err
+		}
+		viewer = v
+	}
+
+	var allThreads []ThreadInfo
+	var cursor *string
+
+	for {
+		threads, pageInfo, err := fetchThreadPage(client, opts.Owner, opts.Repo, opts.PRNumber, cursor)
+		if err != nil {
+			return nil, fmt.Errorf("list review threads: %w", err)
+		}
+
+		for _, t := range threads {
+			if opts.Unresolved && t.IsResolved {
+				continue
+			}
+			if opts.Mine && t.FirstComment.Author != viewer {
+				continue
+			}
+			allThreads = append(allThreads, t)
+		}
+
+		if !pageInfo.HasNextPage {
+			break
+		}
+		cursor = &pageInfo.EndCursor
+	}
+
+	if allThreads == nil {
+		allThreads = []ThreadInfo{}
+	}
+
+	return allThreads, nil
+}
+
+type pageInfo struct {
+	HasNextPage bool   `json:"hasNextPage"`
+	EndCursor   string `json:"endCursor"`
+}
+
+func fetchThreadPage(client ghcli.Querier, owner, repo string, prNumber int, after *string) ([]ThreadInfo, pageInfo, error) {
+	query := `query($owner: String!, $repo: String!, $number: Int!, $after: String) {
+		repository(owner: $owner, name: $repo) {
+			pullRequest(number: $number) {
+				reviewThreads(first: 100, after: $after) {
+					pageInfo {
+						hasNextPage
+						endCursor
+					}
+					nodes {
+						id
+						path
+						line
+						isResolved
+						comments(first: 1) {
+							totalCount
+							nodes {
+								author { login }
+								body
+							}
+						}
+					}
+				}
+			}
+		}
+	}`
+
+	vars := map[string]any{
+		"owner":  owner,
+		"repo":   repo,
+		"number": prNumber,
+	}
+	if after != nil {
+		vars["after"] = *after
+	}
+
+	var result struct {
+		Repository struct {
+			PullRequest struct {
+				ReviewThreads struct {
+					PageInfo pageInfo `json:"pageInfo"`
+					Nodes    []struct {
+						ID         string `json:"id"`
+						Path       string `json:"path"`
+						Line       int    `json:"line"`
+						IsResolved bool   `json:"isResolved"`
+						Comments   struct {
+							TotalCount int `json:"totalCount"`
+							Nodes      []struct {
+								Author struct {
+									Login string `json:"login"`
+								} `json:"author"`
+								Body string `json:"body"`
+							} `json:"nodes"`
+						} `json:"comments"`
+					} `json:"nodes"`
+				} `json:"reviewThreads"`
+			} `json:"pullRequest"`
+		} `json:"repository"`
+	}
+
+	if err := client.Query(query, vars, &result); err != nil {
+		return nil, pageInfo{}, err
+	}
+
+	nodes := result.Repository.PullRequest.ReviewThreads.Nodes
+	threads := make([]ThreadInfo, 0, len(nodes))
+	for _, n := range nodes {
+		t := ThreadInfo{
+			ID:           n.ID,
+			Path:         n.Path,
+			Line:         n.Line,
+			IsResolved:   n.IsResolved,
+			CommentCount: n.Comments.TotalCount,
+		}
+		if len(n.Comments.Nodes) > 0 {
+			t.FirstComment = FirstComment{
+				Author: n.Comments.Nodes[0].Author.Login,
+				Body:   n.Comments.Nodes[0].Body,
+			}
+		}
+		threads = append(threads, t)
+	}
+
+	return threads, result.Repository.PullRequest.ReviewThreads.PageInfo, nil
+}
+
+func fetchViewer(client ghcli.Querier) (string, error) {
+	query := `query { viewer { login } }`
+
+	var result struct {
+		Viewer struct {
+			Login string `json:"login"`
+		} `json:"viewer"`
+	}
+
+	if err := client.Query(query, nil, &result); err != nil {
+		return "", fmt.Errorf("fetch viewer: %w", err)
+	}
+
+	return result.Viewer.Login, nil
+}
+
 func validateSide(side string) error {
 	if !slices.Contains(ValidSides, side) {
 		return fmt.Errorf("invalid side %q, must be LEFT or RIGHT", side)

--- a/internal/review/thread_test.go
+++ b/internal/review/thread_test.go
@@ -2,6 +2,7 @@ package review
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -242,6 +243,160 @@ func TestReplyToThread(t *testing.T) {
 		})
 		assert.ErrorContains(t, err, "reply to thread")
 		assert.ErrorContains(t, err, "network error")
+	})
+}
+
+func TestListThreads(t *testing.T) {
+	// Helper to build a mock that responds to the thread list query.
+	buildListMock := func(threads []ThreadInfo, viewer string) *mockQuerier {
+		return &mockQuerier{
+			queryFunc: func(query string, _ map[string]any, result any) error {
+				if viewer != "" && query == `query { viewer { login } }` {
+					type viewerResp = struct {
+						Viewer struct {
+							Login string `json:"login"`
+						} `json:"viewer"`
+					}
+					r := result.(*viewerResp)
+					r.Viewer.Login = viewer
+					return nil
+				}
+
+				// Use encoding/json to populate the result to avoid type mismatch.
+				type commentNode struct {
+					Author struct {
+						Login string `json:"login"`
+					} `json:"author"`
+					Body string `json:"body"`
+				}
+				type threadNode struct {
+					ID         string `json:"id"`
+					Path       string `json:"path"`
+					Line       int    `json:"line"`
+					IsResolved bool   `json:"isResolved"`
+					Comments   struct {
+						TotalCount int           `json:"totalCount"`
+						Nodes      []commentNode `json:"nodes"`
+					} `json:"comments"`
+				}
+
+				nodes := make([]threadNode, len(threads))
+				for i, t := range threads {
+					n := threadNode{
+						ID:         t.ID,
+						Path:       t.Path,
+						Line:       t.Line,
+						IsResolved: t.IsResolved,
+					}
+					n.Comments.TotalCount = t.CommentCount
+					n.Comments.Nodes = []commentNode{{Body: t.FirstComment.Body}}
+					n.Comments.Nodes[0].Author.Login = t.FirstComment.Author
+					nodes[i] = n
+				}
+
+				payload := map[string]any{
+					"repository": map[string]any{
+						"pullRequest": map[string]any{
+							"reviewThreads": map[string]any{
+								"pageInfo": map[string]any{
+									"hasNextPage": false,
+									"endCursor":   "",
+								},
+								"nodes": nodes,
+							},
+						},
+					},
+				}
+				data, _ := json.Marshal(payload)
+				return json.Unmarshal(data, result)
+			},
+		}
+	}
+
+	sampleThreads := []ThreadInfo{
+		{ID: "PRRT_1", Path: "main.go", Line: 10, IsResolved: false, CommentCount: 2, FirstComment: FirstComment{Author: "alice", Body: "Fix this"}},
+		{ID: "PRRT_2", Path: "main.go", Line: 20, IsResolved: true, CommentCount: 1, FirstComment: FirstComment{Author: "bob", Body: "Looks good"}},
+		{ID: "PRRT_3", Path: "util.go", Line: 5, IsResolved: false, CommentCount: 3, FirstComment: FirstComment{Author: "alice", Body: "Refactor"}},
+	}
+
+	t.Run("list all threads", func(t *testing.T) {
+		mock := buildListMock(sampleThreads, "")
+		threads, err := ListThreads(mock, ListThreadsOptions{
+			Owner: "owner", Repo: "repo", PRNumber: 1,
+		})
+		require.NoError(t, err)
+		assert.Len(t, threads, 3)
+	})
+
+	t.Run("filter unresolved", func(t *testing.T) {
+		mock := buildListMock(sampleThreads, "")
+		threads, err := ListThreads(mock, ListThreadsOptions{
+			Owner: "owner", Repo: "repo", PRNumber: 1,
+			Unresolved: true,
+		})
+		require.NoError(t, err)
+		assert.Len(t, threads, 2)
+		for _, th := range threads {
+			assert.False(t, th.IsResolved)
+		}
+	})
+
+	t.Run("filter mine", func(t *testing.T) {
+		mock := buildListMock(sampleThreads, "alice")
+		threads, err := ListThreads(mock, ListThreadsOptions{
+			Owner: "owner", Repo: "repo", PRNumber: 1,
+			Mine: true,
+		})
+		require.NoError(t, err)
+		assert.Len(t, threads, 2)
+		for _, th := range threads {
+			assert.Equal(t, "alice", th.FirstComment.Author)
+		}
+	})
+
+	t.Run("filter unresolved and mine", func(t *testing.T) {
+		mock := buildListMock(sampleThreads, "bob")
+		threads, err := ListThreads(mock, ListThreadsOptions{
+			Owner: "owner", Repo: "repo", PRNumber: 1,
+			Unresolved: true, Mine: true,
+		})
+		require.NoError(t, err)
+		assert.Empty(t, threads)
+	})
+
+	t.Run("empty result returns empty array", func(t *testing.T) {
+		mock := buildListMock(nil, "")
+		threads, err := ListThreads(mock, ListThreadsOptions{
+			Owner: "owner", Repo: "repo", PRNumber: 1,
+		})
+		require.NoError(t, err)
+		assert.NotNil(t, threads)
+		assert.Empty(t, threads)
+	})
+
+	t.Run("api error", func(t *testing.T) {
+		mock := &mockQuerier{
+			queryFunc: func(_ string, _ map[string]any, _ any) error {
+				return fmt.Errorf("network error")
+			},
+		}
+		_, err := ListThreads(mock, ListThreadsOptions{
+			Owner: "owner", Repo: "repo", PRNumber: 1,
+		})
+		assert.ErrorContains(t, err, "list review threads")
+	})
+
+	t.Run("viewer error", func(t *testing.T) {
+		mock := &mockQuerier{
+			queryFunc: func(_ string, _ map[string]any, _ any) error {
+				return fmt.Errorf("auth error")
+			},
+		}
+		_, err := ListThreads(mock, ListThreadsOptions{
+			Owner: "owner", Repo: "repo", PRNumber: 1,
+			Mine: true,
+		})
+		assert.ErrorContains(t, err, "fetch viewer")
 	})
 }
 


### PR DESCRIPTION
## Summary
- Adds `gh cherry review thread list <pr-number>` to list all review threads for a PR
- Supports `--unresolved` flag to filter only unresolved threads
- Supports `--mine` flag to filter threads started by the authenticated user
- Handles pagination for PRs with many threads

Fixes #11

## Test plan
- [x] Unit tests for all filter combinations (all, unresolved, mine, both)
- [x] Unit tests for empty results, API errors, viewer errors
- [x] Manual test: `gh cherry review thread list 19`
- [x] Manual test: `gh cherry review thread list 19 --unresolved`
- [x] Manual test: `gh cherry review thread list 19 --mine`

🤖 Generated with [Claude Code](https://claude.com/claude-code)