### PR TITLE
feat: add `review thread resolve/unresolve` commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `gh cherry review thread resolve/unresolve` commands to toggle review thread resolution
 - `gh cherry review thread list` command to list review threads with `--unresolved` and `--mine` filters
 - `gh cherry review thread reply` command to reply to existing review threads
 - `gh cherry issue create` command with issue type support (`-T` flag)

--- a/cmd/review.go
+++ b/cmd/review.go
@@ -121,6 +121,24 @@ func init() {
 	threadListCmd.Flags().Bool("mine", false, "Only show threads started by me")
 	threadListCmd.Flags().StringP("repo", "R", "", "Repository in owner/repo format")
 
+	threadResolveCmd := &cobra.Command{
+		Use:   "resolve <thread-id>",
+		Short: "Resolve a review thread",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			return runReviewThreadResolve(args, true)
+		},
+	}
+
+	threadUnresolveCmd := &cobra.Command{
+		Use:   "unresolve <thread-id>",
+		Short: "Unresolve a review thread",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			return runReviewThreadResolve(args, false)
+		},
+	}
+
 	threadCmd := &cobra.Command{
 		Use:   "thread",
 		Short: "Manage review comment threads",
@@ -128,6 +146,8 @@ func init() {
 	threadCmd.AddCommand(threadAddCmd)
 	threadCmd.AddCommand(threadReplyCmd)
 	threadCmd.AddCommand(threadListCmd)
+	threadCmd.AddCommand(threadResolveCmd)
+	threadCmd.AddCommand(threadUnresolveCmd)
 
 	reviewCmd := &cobra.Command{
 		Use:   "review",
@@ -355,6 +375,25 @@ func runReviewThreadList(cmd *cobra.Command, args []string) error {
 	}
 
 	return json.NewEncoder(os.Stdout).Encode(threads)
+}
+
+func runReviewThreadResolve(args []string, resolve bool) error {
+	client, err := ghcli.NewClient()
+	if err != nil {
+		return err
+	}
+
+	var result *review.ResolveThreadResult
+	if resolve {
+		result, err = review.ResolveThread(client, args[0])
+	} else {
+		result, err = review.UnresolveThread(client, args[0])
+	}
+	if err != nil {
+		return err
+	}
+
+	return json.NewEncoder(os.Stdout).Encode(result)
 }
 
 // resolveBody reads the review body from --body or --body-file.

--- a/internal/review/thread.go
+++ b/internal/review/thread.go
@@ -317,6 +317,72 @@ func fetchViewer(client ghcli.Querier) (string, error) {
 	return result.Viewer.Login, nil
 }
 
+// ResolveThreadResult holds the result of resolving or unresolving a thread.
+type ResolveThreadResult struct {
+	ID         string `json:"id"`
+	IsResolved bool   `json:"isResolved"`
+}
+
+// ResolveThread resolves a review thread.
+func ResolveThread(client ghcli.Querier, threadID string) (*ResolveThreadResult, error) {
+	query := `mutation($threadId: ID!) {
+		resolveReviewThread(input: { threadId: $threadId }) {
+			thread {
+				id
+				isResolved
+			}
+		}
+	}`
+
+	var result struct {
+		ResolveReviewThread struct {
+			Thread struct {
+				ID         string `json:"id"`
+				IsResolved bool   `json:"isResolved"`
+			} `json:"thread"`
+		} `json:"resolveReviewThread"`
+	}
+
+	if err := client.Query(query, map[string]any{
+		"threadId": threadID,
+	}, &result); err != nil {
+		return nil, fmt.Errorf("resolve thread: %w", err)
+	}
+
+	t := result.ResolveReviewThread.Thread
+	return &ResolveThreadResult{ID: t.ID, IsResolved: t.IsResolved}, nil
+}
+
+// UnresolveThread unresolves a review thread.
+func UnresolveThread(client ghcli.Querier, threadID string) (*ResolveThreadResult, error) {
+	query := `mutation($threadId: ID!) {
+		unresolveReviewThread(input: { threadId: $threadId }) {
+			thread {
+				id
+				isResolved
+			}
+		}
+	}`
+
+	var result struct {
+		UnresolveReviewThread struct {
+			Thread struct {
+				ID         string `json:"id"`
+				IsResolved bool   `json:"isResolved"`
+			} `json:"thread"`
+		} `json:"unresolveReviewThread"`
+	}
+
+	if err := client.Query(query, map[string]any{
+		"threadId": threadID,
+	}, &result); err != nil {
+		return nil, fmt.Errorf("unresolve thread: %w", err)
+	}
+
+	t := result.UnresolveReviewThread.Thread
+	return &ResolveThreadResult{ID: t.ID, IsResolved: t.IsResolved}, nil
+}
+
 func validateSide(side string) error {
 	if !slices.Contains(ValidSides, side) {
 		return fmt.Errorf("invalid side %q, must be LEFT or RIGHT", side)

--- a/internal/review/thread_test.go
+++ b/internal/review/thread_test.go
@@ -400,6 +400,78 @@ func TestListThreads(t *testing.T) {
 	})
 }
 
+func TestResolveThread(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		mock := &mockQuerier{
+			queryFunc: func(query string, variables map[string]any, result any) error {
+				assert.Contains(t, query, "resolveReviewThread")
+				assert.Equal(t, "PRRT_123", variables["threadId"])
+
+				data, _ := json.Marshal(map[string]any{
+					"resolveReviewThread": map[string]any{
+						"thread": map[string]any{
+							"id":         "PRRT_123",
+							"isResolved": true,
+						},
+					},
+				})
+				return json.Unmarshal(data, result)
+			},
+		}
+
+		res, err := ResolveThread(mock, "PRRT_123")
+		require.NoError(t, err)
+		assert.Equal(t, "PRRT_123", res.ID)
+		assert.True(t, res.IsResolved)
+	})
+
+	t.Run("api error", func(t *testing.T) {
+		mock := &mockQuerier{
+			queryFunc: func(_ string, _ map[string]any, _ any) error {
+				return fmt.Errorf("network error")
+			},
+		}
+		_, err := ResolveThread(mock, "PRRT_123")
+		assert.ErrorContains(t, err, "resolve thread")
+	})
+}
+
+func TestUnresolveThread(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		mock := &mockQuerier{
+			queryFunc: func(query string, variables map[string]any, result any) error {
+				assert.Contains(t, query, "unresolveReviewThread")
+				assert.Equal(t, "PRRT_123", variables["threadId"])
+
+				data, _ := json.Marshal(map[string]any{
+					"unresolveReviewThread": map[string]any{
+						"thread": map[string]any{
+							"id":         "PRRT_123",
+							"isResolved": false,
+						},
+					},
+				})
+				return json.Unmarshal(data, result)
+			},
+		}
+
+		res, err := UnresolveThread(mock, "PRRT_123")
+		require.NoError(t, err)
+		assert.Equal(t, "PRRT_123", res.ID)
+		assert.False(t, res.IsResolved)
+	})
+
+	t.Run("api error", func(t *testing.T) {
+		mock := &mockQuerier{
+			queryFunc: func(_ string, _ map[string]any, _ any) error {
+				return fmt.Errorf("network error")
+			},
+		}
+		_, err := UnresolveThread(mock, "PRRT_123")
+		assert.ErrorContains(t, err, "unresolve thread")
+	})
+}
+
 func TestPrintResult(t *testing.T) {
 	var buf bytes.Buffer
 	err := PrintResult(&AddThreadResult{ThreadID: "PRRT_abc"}, &buf)


### PR DESCRIPTION
## Summary
- Adds `gh cherry review thread resolve <thread-id>` to resolve a review thread
- Adds `gh cherry review thread unresolve <thread-id>` to unresolve a review thread
- Returns updated thread state as JSON `{ "id": "...", "isResolved": true/false }`

Fixes #12

## Test plan
- [x] Unit tests for resolve success and API error
- [x] Unit tests for unresolve success and API error
- [x] Manual test: resolve a real thread on PR #19
- [x] Manual test: unresolve the same thread

🤖 Generated with [Claude Code](https://claude.com/claude-code)