### PR TITLE
feat: add `review thread edit-comment/delete-comment` commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `gh cherry review thread edit-comment/delete-comment` commands to manage review comments
 - `gh cherry review thread resolve/unresolve` commands to toggle review thread resolution
 - `gh cherry review thread list` command to list review threads with `--unresolved` and `--mine` filters
 - `gh cherry review thread reply` command to reply to existing review threads

--- a/cmd/review.go
+++ b/cmd/review.go
@@ -139,6 +139,28 @@ func init() {
 		},
 	}
 
+	threadEditCommentCmd := &cobra.Command{
+		Use:   "edit-comment <comment-id>",
+		Short: "Edit a review comment's body",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runReviewThreadEditComment(cmd, args)
+		},
+	}
+	threadEditCommentCmd.Flags().StringP("body", "b", "", "New comment body")
+	threadEditCommentCmd.Flags().String("body-file", "", "Read body from file")
+	threadEditCommentCmd.MarkFlagsMutuallyExclusive("body", "body-file")
+	threadEditCommentCmd.MarkFlagsOneRequired("body", "body-file")
+
+	threadDeleteCommentCmd := &cobra.Command{
+		Use:   "delete-comment <comment-id>",
+		Short: "Delete a review comment",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			return runReviewThreadDeleteComment(args)
+		},
+	}
+
 	threadCmd := &cobra.Command{
 		Use:   "thread",
 		Short: "Manage review comment threads",
@@ -148,6 +170,8 @@ func init() {
 	threadCmd.AddCommand(threadListCmd)
 	threadCmd.AddCommand(threadResolveCmd)
 	threadCmd.AddCommand(threadUnresolveCmd)
+	threadCmd.AddCommand(threadEditCommentCmd)
+	threadCmd.AddCommand(threadDeleteCommentCmd)
 
 	reviewCmd := &cobra.Command{
 		Use:   "review",
@@ -389,6 +413,39 @@ func runReviewThreadResolve(args []string, resolve bool) error {
 	} else {
 		result, err = review.UnresolveThread(client, args[0])
 	}
+	if err != nil {
+		return err
+	}
+
+	return json.NewEncoder(os.Stdout).Encode(result)
+}
+
+func runReviewThreadEditComment(cmd *cobra.Command, args []string) error {
+	body, err := resolveBody(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := ghcli.NewClient()
+	if err != nil {
+		return err
+	}
+
+	result, err := review.EditComment(client, args[0], body)
+	if err != nil {
+		return err
+	}
+
+	return json.NewEncoder(os.Stdout).Encode(result)
+}
+
+func runReviewThreadDeleteComment(args []string) error {
+	client, err := ghcli.NewClient()
+	if err != nil {
+		return err
+	}
+
+	result, err := review.DeleteComment(client, args[0])
 	if err != nil {
 		return err
 	}

--- a/internal/review/thread.go
+++ b/internal/review/thread.go
@@ -383,6 +383,80 @@ func UnresolveThread(client ghcli.Querier, threadID string) (*ResolveThreadResul
 	return &ResolveThreadResult{ID: t.ID, IsResolved: t.IsResolved}, nil
 }
 
+// EditCommentResult holds the result of editing a review comment.
+type EditCommentResult struct {
+	ID   string `json:"id"`
+	Body string `json:"body"`
+}
+
+// EditComment updates the body of a pull request review comment.
+func EditComment(client ghcli.Querier, commentID, body string) (*EditCommentResult, error) {
+	query := `mutation($commentId: ID!, $body: String!) {
+		updatePullRequestReviewComment(input: {
+			pullRequestReviewCommentId: $commentId,
+			body: $body
+		}) {
+			pullRequestReviewComment {
+				id
+				body
+			}
+		}
+	}`
+
+	var result struct {
+		UpdatePullRequestReviewComment struct {
+			PullRequestReviewComment struct {
+				ID   string `json:"id"`
+				Body string `json:"body"`
+			} `json:"pullRequestReviewComment"`
+		} `json:"updatePullRequestReviewComment"`
+	}
+
+	if err := client.Query(query, map[string]any{
+		"commentId": commentID,
+		"body":      body,
+	}, &result); err != nil {
+		return nil, fmt.Errorf("edit comment: %w", err)
+	}
+
+	c := result.UpdatePullRequestReviewComment.PullRequestReviewComment
+	return &EditCommentResult{ID: c.ID, Body: c.Body}, nil
+}
+
+// DeleteCommentResult holds the result of deleting a review comment.
+type DeleteCommentResult struct {
+	Deleted string `json:"deleted"`
+}
+
+// DeleteComment deletes a pull request review comment.
+func DeleteComment(client ghcli.Querier, commentID string) (*DeleteCommentResult, error) {
+	query := `mutation($commentId: ID!) {
+		deletePullRequestReviewComment(input: { id: $commentId }) {
+			pullRequestReviewComment {
+				id
+			}
+		}
+	}`
+
+	var result struct {
+		DeletePullRequestReviewComment struct {
+			PullRequestReviewComment struct {
+				ID string `json:"id"`
+			} `json:"pullRequestReviewComment"`
+		} `json:"deletePullRequestReviewComment"`
+	}
+
+	if err := client.Query(query, map[string]any{
+		"commentId": commentID,
+	}, &result); err != nil {
+		return nil, fmt.Errorf("delete comment: %w", err)
+	}
+
+	return &DeleteCommentResult{
+		Deleted: result.DeletePullRequestReviewComment.PullRequestReviewComment.ID,
+	}, nil
+}
+
 func validateSide(side string) error {
 	if !slices.Contains(ValidSides, side) {
 		return fmt.Errorf("invalid side %q, must be LEFT or RIGHT", side)

--- a/internal/review/thread_test.go
+++ b/internal/review/thread_test.go
@@ -472,6 +472,77 @@ func TestUnresolveThread(t *testing.T) {
 	})
 }
 
+func TestEditComment(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		mock := &mockQuerier{
+			queryFunc: func(query string, variables map[string]any, result any) error {
+				assert.Contains(t, query, "updatePullRequestReviewComment")
+				assert.Equal(t, "PRRC_123", variables["commentId"])
+				assert.Equal(t, "Updated text", variables["body"])
+
+				data, _ := json.Marshal(map[string]any{
+					"updatePullRequestReviewComment": map[string]any{
+						"pullRequestReviewComment": map[string]any{
+							"id":   "PRRC_123",
+							"body": "Updated text",
+						},
+					},
+				})
+				return json.Unmarshal(data, result)
+			},
+		}
+
+		res, err := EditComment(mock, "PRRC_123", "Updated text")
+		require.NoError(t, err)
+		assert.Equal(t, "PRRC_123", res.ID)
+		assert.Equal(t, "Updated text", res.Body)
+	})
+
+	t.Run("api error", func(t *testing.T) {
+		mock := &mockQuerier{
+			queryFunc: func(_ string, _ map[string]any, _ any) error {
+				return fmt.Errorf("forbidden")
+			},
+		}
+		_, err := EditComment(mock, "PRRC_123", "text")
+		assert.ErrorContains(t, err, "edit comment")
+	})
+}
+
+func TestDeleteComment(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		mock := &mockQuerier{
+			queryFunc: func(query string, variables map[string]any, result any) error {
+				assert.Contains(t, query, "deletePullRequestReviewComment")
+				assert.Equal(t, "PRRC_123", variables["commentId"])
+
+				data, _ := json.Marshal(map[string]any{
+					"deletePullRequestReviewComment": map[string]any{
+						"pullRequestReviewComment": map[string]any{
+							"id": "PRRC_123",
+						},
+					},
+				})
+				return json.Unmarshal(data, result)
+			},
+		}
+
+		res, err := DeleteComment(mock, "PRRC_123")
+		require.NoError(t, err)
+		assert.Equal(t, "PRRC_123", res.Deleted)
+	})
+
+	t.Run("api error", func(t *testing.T) {
+		mock := &mockQuerier{
+			queryFunc: func(_ string, _ map[string]any, _ any) error {
+				return fmt.Errorf("not found")
+			},
+		}
+		_, err := DeleteComment(mock, "PRRC_123")
+		assert.ErrorContains(t, err, "delete comment")
+	})
+}
+
 func TestPrintResult(t *testing.T) {
 	var buf bytes.Buffer
 	err := PrintResult(&AddThreadResult{ThreadID: "PRRT_abc"}, &buf)


### PR DESCRIPTION
## Summary
- Adds `gh cherry review thread edit-comment <comment-id> --body "text"` to edit review comments
- Adds `gh cherry review thread delete-comment <comment-id>` to delete review comments
- Supports `--body-file` for edit-comment

Fixes #13

## Test plan
- [x] Unit tests for edit-comment success and API error
- [x] Unit tests for delete-comment success and API error
- [x] Manual test: create a reply, edit it, then delete it on PR #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)